### PR TITLE
Fix npm dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "pixi-game",
-  "version": "0.0.0",
+  "name": "pixi-rpg-game",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pixi-game",
-      "version": "0.0.0",
+      "name": "pixi-rpg-game",
+      "version": "1.0.0",
       "dependencies": {
         "@pixi/filter-bloom": "^5.1.1",
         "@pixi/filter-crt": "^5.1.1",
         "@pixi/filter-drop-shadow": "^5.2.0",
         "@pixi/filter-glow": "^5.2.1",
-        "pixi.js": "^8.10.1"
+        "pixi.js": "^8.0.0"
       },
       "devDependencies": {
         "vite": "^6.3.5"

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   },
   "dependencies": {
     "pixi.js": "^8.0.0",
-    "@pixi/filter-glow": "^7.2.0",
-    "@pixi/filter-bloom": "^7.2.0",
-    "@pixi/filter-drop-shadow": "^7.2.0",
-    "@pixi/filter-crt": "^7.2.0"
+    "@pixi/filter-glow": "^5.2.1",
+    "@pixi/filter-bloom": "^5.1.1",
+    "@pixi/filter-drop-shadow": "^5.2.0",
+    "@pixi/filter-crt": "^5.1.1"
   },
   "devDependencies": {
-    "vite": "^4.0.0"
+    "vite": "^6.3.5"
   }
 }


### PR DESCRIPTION
## Summary
- fix invalid pixi filter versions in `package.json`
- bump vite devDependency
- regenerate `package-lock.json`

## Testing
- `npm run dev`
- `npm run build` *(fails: terminated after starting build)*

------
https://chatgpt.com/codex/tasks/task_e_68433c0965508331b8c131dd6fc78266