### PR TITLE
Fix dungeon flow and add boss battles

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -297,8 +297,27 @@ export class Game {
         this.initUI();
       });
       this.stage.addChild(battleBtn);
+      // Tlačítko "Battle Boss" pro souboj s aktuálním bossem
+      const bossBtn = new Button('Battle Boss', this.app.screen.width / 2 - 105, 380, 210, 60, 0xffe000);
+      bossBtn.on('pointerdown', () => {
+        if (this.currentBossIndex >= BOSS_ENEMIES.length) {
+          this.message = 'All bosses defeated!';
+          this.initUI();
+          return;
+        }
+        const bossTemplate = BOSS_ENEMIES[this.currentBossIndex];
+        if (this.character.level < bossTemplate.requiredPlayerLevel) {
+          this.message = `Boss requires level ${bossTemplate.requiredPlayerLevel}`;
+          this.initUI();
+          return;
+        }
+        this.enemy = new Enemy(bossTemplate, this.character.level, true, this.character);
+        this.state = 'battle';
+        this.initUI();
+      });
+      this.stage.addChild(bossBtn);
       // Tlačítko "Shop" pro otevření obchodu
-      const shopBtn = new Button('Shop', this.app.screen.width / 2 - 55, 380, 110, 50, 0x00e0ff);
+      const shopBtn = new Button('Shop', this.app.screen.width / 2 - 55, 460, 110, 50, 0x00e0ff);
       shopBtn.on('pointerdown', () => {
         this.state = 'shop';
         this.initUI();
@@ -454,6 +473,7 @@ export class Game {
         char.hp = char.maxHp;
         if (enemy.isBoss) {
           this.bossesDefeated++;
+          this.currentBossIndex++;
           this.message = `You defeated ${enemy.name}!`;
         }
         this.dungeonLevel++;


### PR DESCRIPTION
## Summary
- allow battles with bosses via new `Battle Boss` button
- adjust shop button position
- increment `currentBossIndex` after a boss defeat

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684353024528833181142ef5bdbe9790