### PR TITLE
Fix battle startup state

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -292,7 +292,9 @@ export class Game {
         // Vybrání náhodného nepřítele ze seznamu pro daný dungeon level
         const randomEnemyTemplate = DUNGEON_ENEMIES[Math.floor(Math.random() * DUNGEON_ENEMIES.length)];
         this.enemy = new Enemy(randomEnemyTemplate, this.character.level, false, this.character);
-        // Přechod do stavu boje
+        // Přechod do stavu boje a nastavení hráčova tahu na začátek
+        this.battleTurn = 'player';
+        this.resetBattleState();
         this.state = 'battle';
         this.initUI();
       });
@@ -312,6 +314,9 @@ export class Game {
           return;
         }
         this.enemy = new Enemy(bossTemplate, this.character.level, true, this.character);
+        // Zahájení nového boje s bossem
+        this.battleTurn = 'player';
+        this.resetBattleState();
         this.state = 'battle';
         this.initUI();
       });


### PR DESCRIPTION
## Summary
- fix starting state for battles
- reset battle status when selecting Battle or Boss fights

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68454bf93b7c833181d60f1ea64e578a