### PR TITLE
Fix battle system turn logic

### DIFF
--- a/src/components/BattleSystem.js
+++ b/src/components/BattleSystem.js
@@ -76,6 +76,28 @@ export class BattleSystem {
       game.stage.addChild(game.attackEffect);
     }
     // (Pozn.: Další efekty pro jiné třídy by mohly být doplněny obdobně)
+
+    // Krátké zvýraznění nepřítele při zásahu
+    game.enemyFlashTimer = 0.1;
+
+    // Kontrola existence sprite; pokud chybí, znovu vykreslit UI
+    if (!game.charShape || !game.enemyShape) {
+      game.initUI();
+      return;
+    }
+
+    // Pokud nepřítel zemřel, ukončí se boj
+    if (enemy.hp <= 0) {
+      game.battleTurn = 'none';
+      game.playerAttacking = false;
+      game.initUI();
+      return;
+    }
+
+    // Přepnutí na tah nepřítele a nastavení odpočtu pro další útok
+    game.playerAttacking = false;
+    game.battleTurn = 'enemy';
+    game.autoBattleTimer = game.autoBattleDelay;
   }
 
   static doEnemyAttack(game) {

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -864,20 +864,20 @@ export class Game {
         this.attackEffectAnimProgress += 0.05 * delta;
         if (char.cls.name === 'Street Samurai') {
           const progress = this.attackEffectAnimProgress;
-          game.attackEffect.x = this.charShape.x + 30 + progress * 80;
-          game.attackEffect.y = this.charShape.y - 10 - progress * 20;
-          game.attackEffect.alpha = 1 - progress;
-          game.attackEffect.rotation = -Math.PI / 4 + progress * Math.PI / 2;
+          this.attackEffect.x = this.charShape.x + 30 + progress * 80;
+          this.attackEffect.y = this.charShape.y - 10 - progress * 20;
+          this.attackEffect.alpha = 1 - progress;
+          this.attackEffect.rotation = -Math.PI / 4 + progress * Math.PI / 2;
         } else if (char.cls.name === 'Netrunner' || char.cls.name === 'Techie') {
           const progress = this.attackEffectAnimProgress;
-          game.attackEffect.x = this.charShape.x + 30 + (this.enemyShape.x - this.charShape.x - 30) * progress;
-          game.attackEffect.y = this.charShape.y + (this.enemyShape.y - this.charShape.y) * progress;
+          this.attackEffect.x = this.charShape.x + 30 + (this.enemyShape.x - this.charShape.x - 30) * progress;
+          this.attackEffect.y = this.charShape.y + (this.enemyShape.y - this.charShape.y) * progress;
         }
         if (this.attackEffectAnimProgress >= 1) {
-          this.battleContainer.removeChild(game.attackEffect);
-          game.attackEffect.destroy();
-          game.attackEffect = null;
-          game.attackEffectAnimProgress = 0;
+          this.battleContainer.removeChild(this.attackEffect);
+          this.attackEffect.destroy();
+          this.attackEffect = null;
+          this.attackEffectAnimProgress = 0;
         }
       }
       // Animace útoku nepřítele (posun avataru nepřítele při útoku)


### PR DESCRIPTION
## Summary
- update attack effect animation to use `this` context
- handle end-of-turn logic for player attack and trigger enemy turn

## Testing
- `node --check src/components/Game.js`
- `node --check src/components/BattleSystem.js`


------
https://chatgpt.com/codex/tasks/task_e_68455cc99e248331b1a48cda0f794e35