### PR TITLE
Add battle combo mechanics and avatar fields

### DIFF
--- a/src/components/BattleSystem.js
+++ b/src/components/BattleSystem.js
@@ -33,6 +33,15 @@ export class BattleSystem {
       playerDmg = Math.floor(playerDmg * critMultiplier);
       playerCrit = true;
     }
+    // Bonus za combo – po rychlých po sobě jdoucích útocích roste poškození
+    if (game.comboCount > 0 && game.comboTimer < game.comboTimerMax) {
+      game.comboCount++;
+      playerDmg = Math.floor(playerDmg * (1 + game.comboCount * 0.1));
+      game.spawnFloatingText(`x${game.comboCount}`, game.charShape.x, game.charShape.y - 40, 0xffe000, 20, -20);
+    } else {
+      game.comboCount = 1;
+    }
+    game.comboTimer = 0;
     // Aplikace zásahu – ubrání HP nepřítele
     enemy.hp = Math.max(0, enemy.hp - playerDmg);
     // Pokud nebyly inicializovány sprity postav, obnovit UI
@@ -158,6 +167,9 @@ export class BattleSystem {
     } else {
       game.spawnFloatingText(enemyDmg.toString(), game.charShape.x + game.charShape.width / 2, game.charShape.y, textColor, textSize, -30);
       if (enemyDmg > 0) {
+        // Zásah hráče přeruší případné combo
+        game.comboCount = 0;
+        game.comboTimer = 0;
         // Efekt "krve" při zásahu hráče (malé červené částice)
         if (!game.bloodEffects) game.bloodEffects = [];
         for (let i = 0; i < 7; i++) {

--- a/src/components/Character.js
+++ b/src/components/Character.js
@@ -2,6 +2,8 @@ export class Character {
   constructor(cls) {
     // Inicializace základních atributů podle zvolené třídy (class)
     this.cls = cls;
+    // Cesta k avataru postavy pro zobrazování v boji
+    this.avatar = cls.texture;
     this.level = 1;
     this.exp = 0;
     this.expToNext = 50;

--- a/src/components/Enemy.js
+++ b/src/components/Enemy.js
@@ -1,3 +1,5 @@
+import { ENEMY_ASSETS } from '../data/enemyAssets.js';
+
 export class Enemy {
   constructor(template, playerLevel = 1, isBoss = false, playerRef = null) {
     this.isBoss = isBoss || template.isBoss || false;
@@ -45,6 +47,11 @@ export class Enemy {
     if (this.isBoss && template.texture) {
       // U bossů můžeme mít speciální texturu (obrázek)
       this.texture = template.texture;
+    } else if (ENEMY_ASSETS[template.name]) {
+      // Běžným nepřátelům přiřadíme texturu z mapy assetů
+      this.texture = ENEMY_ASSETS[template.name];
     }
+    // Avatar použije stejnou texturu
+    this.avatar = this.texture || ENEMY_ASSETS['Gang Thug'];
   }
 }

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -466,7 +466,7 @@ export class Game {
       new DropShadowFilter({ distance: 0, blur: 8, color: 0x000000, alpha: 0.5 })
     ];
     this.battleContainer.addChild(playerBgSprite);
-    const charAvatar = PIXI.Sprite.from(char.cls.texture);
+    const charAvatar = PIXI.Sprite.from(char.avatar);
     charAvatar.width = AVATAR_SIZE;
     charAvatar.height = AVATAR_SIZE;
     charAvatar.anchor.set(0.5);
@@ -514,7 +514,7 @@ export class Game {
     ];
     this.battleContainer.addChild(enemyBgSprite);
     // Sprite nepřítele (obrázek buď specifický pro bosse, nebo obecný z ENEMY_ASSETS)
-    const enemyTexture = (enemy.isBoss && enemy.texture) ? enemy.texture : (ENEMY_ASSETS[enemy.name] || ENEMY_ASSETS['Gang Thug']);
+    const enemyTexture = enemy.avatar;
     const enemySprite = PIXI.Sprite.from(enemyTexture);
     enemySprite.width = AVATAR_SIZE;
     enemySprite.height = AVATAR_SIZE;
@@ -747,6 +747,8 @@ export class Game {
     this.app.stage.y = 0;
     this.playerFlashTimer = 0;
     this.enemyFlashTimer = 0;
+    this.comboCount = 0;
+    this.comboTimer = 0;
     this.playerAttacksWithoutDamage = 0;
     this.charShape = null;
     this.enemyShape = null;
@@ -915,6 +917,14 @@ export class Game {
         if (text.alpha <= 0) {
           this.battleContainer.removeChild(text);
           this.floatingTexts.splice(i, 1);
+        }
+      }
+      // Časovač komba – pokud neútočíme dostatečně rychle, kombo se vynuluje
+      if (this.comboCount > 0) {
+        this.comboTimer += delta / 60;
+        if (this.comboTimer > this.comboTimerMax) {
+          this.comboCount = 0;
+          this.comboTimer = 0;
         }
       }
       // Auto-battle logika: pokud nikdo zrovna neútočí, odpočítá čas a spustí další útok


### PR DESCRIPTION
## Summary
- track avatar for characters and enemies
- use avatar textures when rendering battle scene
- implement combo damage mechanic in battle system
- reset combo timer and count appropriately

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684562a2ecd08331b3bc3020a5ec66f0