### PR TITLE
Restore energy turn order

### DIFF
--- a/src/components/StrategicBattleSystem.js
+++ b/src/components/StrategicBattleSystem.js
@@ -17,14 +17,18 @@ export class StrategicBattleSystem {
     game.enemyEnergy = Math.min(game.energyMax, game.enemyEnergy + enemy.spd * delta);
 
     if (!game.playerAttacking && !game.enemyAttacking && char.hp > 0 && enemy.hp > 0) {
-      if (game.battleTurn === 'player' && game.playerEnergy >= game.energyThreshold) {
-        const cost = game.playerEnergy >= game.energyMax ? game.energyMax : game.energyThreshold;
-        const mult = game.playerEnergy >= game.energyMax ? 1.5 : 1;
+      const pEn = game.playerEnergy;
+      const eEn = game.enemyEnergy;
+      if (pEn < game.energyThreshold && eEn < game.energyThreshold) return;
+
+      if (pEn >= eEn) {
+        const cost = pEn >= game.energyMax ? game.energyMax : game.energyThreshold;
+        const mult = pEn >= game.energyMax ? 1.5 : 1;
         game.playerEnergy -= cost;
         BattleSystem.doPlayerAttack(game, mult);
-      } else if (game.battleTurn === 'enemy' && game.enemyEnergy >= game.energyThreshold) {
-        const cost = game.enemyEnergy >= game.energyMax ? game.energyMax : game.energyThreshold;
-        const mult = game.enemyEnergy >= game.energyMax ? 1.5 : 1;
+      } else {
+        const cost = eEn >= game.energyMax ? game.energyMax : game.energyThreshold;
+        const mult = eEn >= game.energyMax ? 1.5 : 1;
         game.enemyEnergy -= cost;
         BattleSystem.doEnemyAttack(game, mult);
       }


### PR DESCRIPTION
## Summary
- fix the energy threshold logic so the actor with higher energy attacks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684589e8cf788331bbae89d6ba497bf7