### PR TITLE
Fix energy bar NaN display

### DIFF
--- a/src/components/StatBar.js
+++ b/src/components/StatBar.js
@@ -29,8 +29,8 @@ export class StatBar extends PIXI.Container {
   }
 
   updateBar(val, max) {
-    this.value = val;
-    this.max = max;
+    this.value = Number.isFinite(val) ? val : 0;
+    this.max = Number.isFinite(max) && max > 0 ? max : 1;
     // Aktualizace grafické výplně podle poměru value/max
     this.fg.clear();
     this.fg.beginFill(this.fill);

--- a/src/components/StrategicBattleSystem.js
+++ b/src/components/StrategicBattleSystem.js
@@ -20,11 +20,13 @@ export class StrategicBattleSystem {
 
     game.playerEnergy = Math.max(0, Math.min(
       game.energyMax,
-      game.playerEnergy + playerSpd * delta * ENERGY_GAIN_RATE
+      (Number.isFinite(game.playerEnergy) ? game.playerEnergy : 0) +
+        playerSpd * delta * ENERGY_GAIN_RATE
     ));
     game.enemyEnergy = Math.max(0, Math.min(
       game.energyMax,
-      game.enemyEnergy + enemySpd * delta * ENERGY_GAIN_RATE
+      (Number.isFinite(game.enemyEnergy) ? game.enemyEnergy : 0) +
+        enemySpd * delta * ENERGY_GAIN_RATE
     ));
 
     if (!game.playerAttacking && !game.enemyAttacking && char.hp > 0 && enemy.hp > 0) {


### PR DESCRIPTION
## Summary
- ensure energy accumulation never results in NaN
- safeguard StatBar updates against invalid values

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684594f58cdc8331a497e38fb1600d6f