### PR TITLE
Improve shop scaling and remove item level requirements

### DIFF
--- a/src/components/Character.js
+++ b/src/components/Character.js
@@ -70,7 +70,6 @@ export class Character {
     const isOwned = (type === 'weapon' ? this.inventory.weapons : this.inventory.armors)
       .some(i => i.name === itemTemplate.name);
     if (isOwned) return false;
-    if (this.level < itemTemplate.requiredPlayerLevel) return false;
     const cost = this.getItemCost(itemTemplate);
     if (this.gold >= cost) {
       this.gold -= cost;

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -726,7 +726,7 @@ export class Game {
     shopTitle.y = 20;
     this.stage.addChild(shopTitle);
     // Šířka nabídky obchodu
-    const shopWidth = 780;
+    const shopWidth = Math.min(1000, this.app.screen.width * 0.8);
     const startX = this.app.screen.width / 2 - shopWidth / 2;
     // Tlačítka pro přepínání mezi zbraněmi a zbrojemi
     const weaponsTab = new Button('Weapons', startX, 60, 120, 40, 0x00e0ff);
@@ -771,17 +771,13 @@ export class Game {
       itemNameText.x = startX + 80;
       itemNameText.y = y + shopMaskY + 10;
       this.shopItemsContainer.addChild(itemNameText);
-      // Cena a požadovaný level
+      // Cena
       const priceText = new PIXI.Text(`${itemTemplate.baseCost} G`, { fontFamily: 'monospace', fontSize: 18, fill: 0xffe000 });
-      priceText.x = startX + 640;
+      priceText.x = startX + shopWidth - 140;
       priceText.y = y + shopMaskY + 15;
       this.shopItemsContainer.addChild(priceText);
-      const levelReqText = new PIXI.Text(`Req Lv: ${itemTemplate.requiredPlayerLevel}`, { fontFamily: 'monospace', fontSize: 14, fill: 0xcccccc });
-      levelReqText.x = startX + 640;
-      levelReqText.y = y + shopMaskY + 32;
-      this.shopItemsContainer.addChild(levelReqText);
       // Tlačítko "Buy"
-      const buyBtn = new Button('Buy', startX + 740, y + shopMaskY + 10, 60, 36, 0x00ff8a);
+      const buyBtn = new Button('Buy', startX + shopWidth - 40, y + shopMaskY + 10, 60, 36, 0x00ff8a);
       buyBtn.on('pointerdown', () => {
         // Pokus o koupi předmětu
         const success = this.character.buyItem(itemTemplate, this.shopType === 'weapon' ? 'weapon' : 'armor');

--- a/src/data/armorItems.js
+++ b/src/data/armorItems.js
@@ -1,10 +1,10 @@
 export const ARMOR_ITEMS = [
-  { name: 'Scavenger Vest', baseCost: 40, baseDef: 4, requiredPlayerLevel: 0 },
-  { name: 'Reinforced Jacket', baseCost: 80, baseDef: 8, requiredPlayerLevel: 3 },
-  { name: 'Ballistic Weave', baseCost: 140, baseDef: 12, requiredPlayerLevel: 6 },
-  { name: 'Exo-Plate Armor', baseCost: 200, baseDef: 16, requiredPlayerLevel: 9 },
-  { name: 'Chitin Plating', baseCost: 280, baseDef: 20, requiredPlayerLevel: 12 },
-  { name: 'Reactive Shield', baseCost: 380, baseDef: 24, requiredPlayerLevel: 15 },
-  { name: 'Stealth Suit', baseCost: 520, baseDef: 28, requiredPlayerLevel: 18 },
-  { name: 'Aegis Sentinel', baseCost: 700, baseDef: 32, requiredPlayerLevel: 21 }
+  { name: 'Scavenger Vest', baseCost: 50, baseDef: 4, requiredPlayerLevel: 0 },
+  { name: 'Reinforced Jacket', baseCost: 134, baseDef: 8, requiredPlayerLevel: 0 },
+  { name: 'Ballistic Weave', baseCost: 360, baseDef: 12, requiredPlayerLevel: 0 },
+  { name: 'Exo-Plate Armor', baseCost: 965, baseDef: 16, requiredPlayerLevel: 0 },
+  { name: 'Chitin Plating', baseCost: 2590, baseDef: 20, requiredPlayerLevel: 0 },
+  { name: 'Reactive Shield', baseCost: 6947, baseDef: 24, requiredPlayerLevel: 0 },
+  { name: 'Stealth Suit', baseCost: 18638, baseDef: 28, requiredPlayerLevel: 0 },
+  { name: 'Aegis Sentinel', baseCost: 50000, baseDef: 32, requiredPlayerLevel: 0 }
 ];

--- a/src/data/weaponItems.js
+++ b/src/data/weaponItems.js
@@ -1,10 +1,10 @@
 export const WEAPON_ITEMS = [
   { name: 'Rusty Blade', baseCost: 50, baseAtk: 6, requiredPlayerLevel: 0 },
-  { name: 'Scrap Pistol', baseCost: 90, baseAtk: 10, requiredPlayerLevel: 3 },
-  { name: 'Energy Baton', baseCost: 150, baseAtk: 14, requiredPlayerLevel: 6 },
-  { name: 'Plasma Rifle', baseCost: 220, baseAtk: 18, requiredPlayerLevel: 9 },
-  { name: 'Monowire Whip', baseCost: 300, baseAtk: 22, requiredPlayerLevel: 12 },
-  { name: 'Pulse Cannon', baseCost: 400, baseAtk: 26, requiredPlayerLevel: 15 },
-  { name: 'Nano-Katana', baseCost: 550, baseAtk: 30, requiredPlayerLevel: 18 },
-  { name: 'Singularity Gun', baseCost: 750, baseAtk: 35, requiredPlayerLevel: 21 }
+  { name: 'Scrap Pistol', baseCost: 134, baseAtk: 10, requiredPlayerLevel: 0 },
+  { name: 'Energy Baton', baseCost: 360, baseAtk: 14, requiredPlayerLevel: 0 },
+  { name: 'Plasma Rifle', baseCost: 965, baseAtk: 18, requiredPlayerLevel: 0 },
+  { name: 'Monowire Whip', baseCost: 2590, baseAtk: 22, requiredPlayerLevel: 0 },
+  { name: 'Pulse Cannon', baseCost: 6947, baseAtk: 26, requiredPlayerLevel: 0 },
+  { name: 'Nano-Katana', baseCost: 18638, baseAtk: 30, requiredPlayerLevel: 0 },
+  { name: 'Singularity Gun', baseCost: 50000, baseAtk: 35, requiredPlayerLevel: 0 }
 ];


### PR DESCRIPTION
## Summary
- widen shop layout for wide screens
- remove purchase level cap
- rescale item costs from 50g to 50000g

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849adeb50e08331afdbf0abee9de40c