### PR TITLE
Modify item bonuses to be percentage-based

### DIFF
--- a/src/components/Character.js
+++ b/src/components/Character.js
@@ -41,13 +41,15 @@ export class Character {
     };
   }
 
-  // Výpočet útoku zbraně pro daný level postavy
+  // Výpočet bonusu zbraně pro daný level postavy (v procentech základního ATK)
   getWeaponStat(item, playerLevel) {
-    return item.baseAtk + Math.floor(playerLevel * 0.5);
+    const percent = item.baseAtk + Math.floor(playerLevel * 0.5);
+    return Math.round(this.baseStats.atk * percent / 100);
   }
-  // Výpočet obrany zbroje pro daný level postavy
+  // Výpočet bonusu zbroje pro daný level postavy (v procentech základního HP)
   getArmorStat(item, playerLevel) {
-    return item.baseDef + Math.floor(playerLevel * 0.5);
+    const percent = item.baseDef + Math.floor(playerLevel * 0.5);
+    return Math.round(this.baseStats.hp * percent / 100);
   }
   // Cena předmětu (základní cena, mohla by být modifikována)
   getItemCost(item) {
@@ -60,7 +62,7 @@ export class Character {
       this.weapon = { ...item, atk: this.getWeaponStat(item, this.level) };
     }
     if (item.type === 'armor') {
-      this.armor = { ...item, def: this.getArmorStat(item, this.level) };
+      this.armor = { ...item, hp: this.getArmorStat(item, this.level) };
     }
     this.updateStats();
   }
@@ -97,9 +99,9 @@ export class Character {
       this.stats.atk += this.weapon.atk;
     }
     if (this.armor && this.armor.baseDef !== undefined) {
-      this.stats.def += this.getArmorStat(this.armor, this.level);
-    } else if (this.armor && this.armor.def !== undefined) {
-      this.stats.def += this.armor.def;
+      this.stats.hp += this.getArmorStat(this.armor, this.level);
+    } else if (this.armor && this.armor.hp !== undefined) {
+      this.stats.hp += this.armor.hp;
     }
     // U různých tříd může mít HP jiný násobitel
     let hpMultiplier = 50;

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -774,7 +774,7 @@ export class Game {
       const statValue = this.shopType === 'weapon'
         ? this.character.getWeaponStat(itemTemplate, this.character.level)
         : this.character.getArmorStat(itemTemplate, this.character.level);
-      const statLabel = this.shopType === 'weapon' ? 'ATK' : 'DEF';
+      const statLabel = this.shopType === 'weapon' ? 'ATK' : 'HP';
       const statText = new PIXI.Text(`${statLabel}: ${statValue}`, { fontFamily: 'monospace', fontSize: 18, fill: 0x00ff8a });
       statText.x = startX + 80;
       statText.y = y + shopMaskY + 40;


### PR DESCRIPTION
## Summary
- change `getWeaponStat` and `getArmorStat` to return percentage-based bonuses
- armor now grants HP instead of DEF
- adjust equip handling for new bonus fields
- update shop UI to display HP bonus for armors

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c44664ec833197c34fec66ec1856