### PR TITLE
Fix enemy stat scaling

### DIFF
--- a/src/components/Enemy.js
+++ b/src/components/Enemy.js
@@ -1,6 +1,8 @@
 import { ENEMY_ASSETS } from '../data/enemyAssets.js';
 
 export class Enemy {
+  static LEVEL_MULTIPLIER = 0.8; // base multiplier for normal enemies
+
   constructor(template, playerLevel = 1, isBoss = false, playerRef = null) {
     this.isBoss = isBoss || template.isBoss || false;
     this.level = template.requiredPlayerLevel;
@@ -18,22 +20,11 @@ export class Enemy {
       // Běžný nepřítel – náhodná úroveň v rozmezí hráčLevel ± 1
       let enemyLevel = Math.max(1, playerLevel + Math.floor(Math.random() * 3) - 1);
       this.level = enemyLevel;
-      // Porovnání součtu statistik hráče a nepřítele pro škálování
-      let playerStatsSource = playerRef ? playerRef : null;
-      let playerTotalStats = 0;
-      if (playerStatsSource) {
-        playerTotalStats = playerStatsSource.stats.hp + playerStatsSource.stats.atk +
-                           playerStatsSource.stats.def + playerStatsSource.stats.spd;
-      } else {
-        playerTotalStats = 100;
-      }
-      const minTarget = Math.max(1, playerTotalStats - 10);
-      const maxTarget = playerTotalStats + 10;
-      const targetBenchmark = minTarget + Math.random() * (maxTarget - minTarget);
-      const enemyTemplateTotal = template.hp + template.atk + template.def + template.spd;
-      let scalingFactor = (enemyTemplateTotal > 0) ? (targetBenchmark / enemyTemplateTotal) : 1;
-      scalingFactor *= 1.44;
-      // Vypočtené statistiky nepřítele, zaokrouhleno a s minimální hodnotou 1
+      // Benchmark je součet základních statistik * LEVEL_MULTIPLIER * úroveň
+      const baseTotal = template.hp + template.atk + template.def + template.spd;
+      const targetTotal = baseTotal * Enemy.LEVEL_MULTIPLIER * this.level;
+      const scalingFactor = (baseTotal > 0) ? (targetTotal / baseTotal) : 1;
+      // Vypočetené statistiky nepřítele, zaokrouhleno a s minimální hodnotou 1
       this.hp = Math.max(1, Math.round(template.hp * scalingFactor));
       this.atk = Math.max(1, Math.round(template.atk * scalingFactor));
       this.def = Math.max(1, Math.round(template.def * scalingFactor));


### PR DESCRIPTION
## Summary
- tweak enemy level scaling logic so normal enemies don't grow too strong

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849c67e4e708331b9bcd19bc7c5550a