### PR TITLE
Improve enemy stat balance

### DIFF
--- a/src/components/Enemy.js
+++ b/src/components/Enemy.js
@@ -20,15 +20,22 @@ export class Enemy {
       // Běžný nepřítel – náhodná úroveň v rozmezí hráčLevel ± 1
       let enemyLevel = Math.max(1, playerLevel + Math.floor(Math.random() * 3) - 1);
       this.level = enemyLevel;
-      // Benchmark je součet základních statistik * LEVEL_MULTIPLIER * úroveň
+      // Cílový součet statistik vychází ze startovních statů hráče a navýšení 3 za každý level
+      let playerStartTotal = 147;
+      if (playerRef && playerRef.cls) {
+        const c = playerRef.cls;
+        playerStartTotal = c.hp + c.atk + c.def + c.spd;
+      }
+      const targetTotal = playerStartTotal + (this.level - 1) * 3;
       const baseTotal = template.hp + template.atk + template.def + template.spd;
-      const targetTotal = baseTotal * Enemy.LEVEL_MULTIPLIER * this.level;
-      const scalingFactor = (baseTotal > 0) ? (targetTotal / baseTotal) : 1;
-      // Vypočetené statistiky nepřítele, zaokrouhleno a s minimální hodnotou 1
-      this.hp = Math.max(1, Math.round(template.hp * scalingFactor));
-      this.atk = Math.max(1, Math.round(template.atk * scalingFactor));
-      this.def = Math.max(1, Math.round(template.def * scalingFactor));
-      this.spd = Math.max(1, Math.round(template.spd * scalingFactor));
+      const scalingFactor = baseTotal > 0 ? (targetTotal / baseTotal) : 1;
+      const variance = 0.05;
+      const rand = () => 1 + ((Math.random() * 2 - 1) * variance);
+      // Vypočtené statistiky nepřítele, zaokrouhleno a s minimální hodnotou 1
+      this.hp = Math.max(1, Math.round(template.hp * scalingFactor * rand()));
+      this.atk = Math.max(1, Math.round(template.atk * scalingFactor * rand()));
+      this.def = Math.max(1, Math.round(template.def * scalingFactor * rand()));
+      this.spd = Math.max(1, Math.round(template.spd * scalingFactor * rand()));
       this.gold = Math.max(1, Math.round(template.gold * scalingFactor));
       this.exp = Math.max(1, Math.round(template.exp * scalingFactor));
     }


### PR DESCRIPTION
## Summary
- tweak enemy stat scaling to use player's starting stats plus a small level-based increase
- add slight randomness while keeping totals near player baseline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849c90802d48331861fdf8e1c8eb67e