### PR TITLE
Fix music autoplay at game start

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -90,7 +90,7 @@ export class Game {
     this.loadAssets().then(() => {
       this.state = 'charcreate';
       this.initUI();
-      this.playBackgroundMusic();
+      // Music playback will start after the first user interaction
     });
   }
 
@@ -254,6 +254,8 @@ export class Game {
         }
         this.state = 'mainmenu';
         this.initUI();
+        // Play background music after user interaction to avoid autoplay blocks
+        this.playBackgroundMusic();
       });
       this.stage.addChild(startBtn);
     } else if (this.state === 'mainmenu') {


### PR DESCRIPTION
## Summary
- only start playing background music after user interaction

## Testing
- `pre-commit` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_6849d96a1f408331ae992cbf4eabcefd