### PR TITLE
Add background glitch effect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@pixi/filter-bloom": "^5.1.1",
         "@pixi/filter-crt": "^5.1.1",
         "@pixi/filter-drop-shadow": "^5.2.0",
+        "@pixi/filter-glitch": "^5.1.1",
         "@pixi/filter-glow": "^5.2.1",
         "pixi.js": "^8.0.0"
       },
@@ -542,6 +543,15 @@
       "dependencies": {
         "@pixi/filter-kawase-blur": "5.1.1"
       },
+      "peerDependencies": {
+        "@pixi/core": "^7.0.0-X"
+      }
+    },
+    "node_modules/@pixi/filter-glitch": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-glitch/-/filter-glitch-5.1.1.tgz",
+      "integrity": "sha512-pl6jOQlzQGg6NwqCwlgioYhlwue2OSRBGByDzh6Y6Y/qxMBuzQi7W56GunhQW79Kpvj9ynDLAGxomvZsrX88qg==",
+      "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "^7.0.0-X"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@pixi/filter-glow": "^5.2.1",
     "@pixi/filter-bloom": "^5.1.1",
     "@pixi/filter-drop-shadow": "^5.2.0",
-    "@pixi/filter-crt": "^5.1.1"
+    "@pixi/filter-crt": "^5.1.1",
+    "@pixi/filter-glitch": "^5.1.1"
   },
   "devDependencies": {
     "vite": "^6.3.5"

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -3,6 +3,7 @@ import { GlowFilter } from '@pixi/filter-glow';
 import { BloomFilter } from '@pixi/filter-bloom';
 import { DropShadowFilter } from '@pixi/filter-drop-shadow';
 import { CRTFilter } from '@pixi/filter-crt';
+import { GlitchFilter } from '@pixi/filter-glitch';
 import { BlurFilter } from 'pixi.js';
 
 import { Button } from './Button.js';
@@ -57,6 +58,9 @@ export class Game {
     this.bossesDefeated = 0;
     this.currentBossIndex = 0;
     this.bgDistortFilter = null;
+    this.glitchFilter = null;
+    this.glitchTimer = 0;
+    this.nextGlitchIn = 0;
     this.logoSprite = null;
     this.comboCount = 0;
     this.comboTimer = 0;
@@ -120,7 +124,10 @@ export class Game {
       seed: Math.random()
     });
     this.bgDistortFilter.time = 0;
-    this.backgroundSprite.filters = [this.bgDistortFilter];
+    this.glitchFilter = new GlitchFilter();
+    this.glitchFilter.enabled = false;
+    this.nextGlitchIn = 3 + Math.random() * 5;
+    this.backgroundSprite.filters = [this.bgDistortFilter, this.glitchFilter];
 
     this.logoSprite = PIXI.Sprite.from('/assets/Logo.png');
     this.logoSprite.width = 120;
@@ -956,6 +963,21 @@ export class Game {
     // Animace zkreslení pozadí (CRT efekt)
     if (this.bgDistortFilter) {
       this.bgDistortFilter.time += 0.03 * delta;
+    }
+    if (this.glitchFilter) {
+      if (this.glitchTimer > 0) {
+        this.glitchTimer -= delta / 60;
+        if (this.glitchTimer <= 0) {
+          this.glitchFilter.enabled = false;
+          this.nextGlitchIn = 3 + Math.random() * 5;
+        }
+      } else {
+        this.nextGlitchIn -= delta / 60;
+        if (this.nextGlitchIn <= 0) {
+          this.glitchFilter.enabled = true;
+          this.glitchTimer = 0.15;
+        }
+      }
     }
     // Aktualizace animace všech tlačítek (Button.updateAnimation)
     this.stage.children.forEach(child => {


### PR DESCRIPTION
## Summary
- add `@pixi/filter-glitch` dependency
- initialize glitch filter for the background
- randomly enable a short glitch in `update`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849da86ea2883319d634e5016d2eac5