### PR TITLE
Refine ability generation

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -782,19 +782,29 @@ export class Game {
       this.battleContainer.removeChild(this.abilityButtons);
       this.abilityButtons.destroy({ children: true });
     }
-    const cont = new PIXI.Container();
+    const overlay = new PIXI.Container();
+    overlay.zIndex = 10;
+    const bg = new PIXI.Graphics();
+    bg.beginFill(0x000000, 0.6);
+    bg.drawRect(0, 0, this.app.screen.width, this.app.screen.height);
+    bg.endFill();
+    overlay.addChild(bg);
+
     const startX = this.app.screen.width / 2 - 330;
+    const startY = this.app.screen.height / 2 - 60;
     abilities.forEach((ab, idx) => {
-      const btn = new Button(ab.name, startX + idx * 220, this.app.screen.height - 140, 200, 50, 0x00e0ff);
-      btn.on('pointerdown', () => {
+      const card = new Button(ab.name, startX + idx * 220, startY, 200, 100, 0x00e0ff);
+      card.on('pointerdown', () => {
         if (this.battleStarted) {
+          this.battleContainer.removeChild(overlay);
+          this.abilityButtons = null;
           BattleSystem.useAbility(this, ab);
         }
       });
-      cont.addChild(btn);
+      overlay.addChild(card);
     });
-    this.battleContainer.addChild(cont);
-    this.abilityButtons = cont;
+    this.battleContainer.addChild(overlay);
+    this.abilityButtons = overlay;
   }
 
   createShopUI() {

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -14,8 +14,12 @@ export class BattleSystem {
   static generateAbilities(game) {
     const pool = ABILITIES[game.character.cls.name] || [];
     BattleSystem.currentAbilities = [];
-    for (let i = 0; i < 3; i++) {
-      const ability = pool[Math.floor(Math.random() * pool.length)];
+    // first slot is the class basic ability if available
+    const baseAbility = pool[0] || { name: '???', description: '', execute() {} };
+    BattleSystem.currentAbilities.push(baseAbility);
+    // remaining slots are placeholders for future abilities
+    for (let i = 1; i < 3; i++) {
+      const ability = pool[i] || { name: '???', description: '', execute() {} };
       BattleSystem.currentAbilities.push(ability);
     }
     if (typeof game.showAbilityOptions === 'function') {

--- a/src/data/abilities.js
+++ b/src/data/abilities.js
@@ -1,3 +1,14 @@
+export const BASIC_ATTACK = {
+  name: 'Basic Attack',
+  description: 'A straightforward strike dealing damage.',
+  execute(game) {
+    const { character: char, enemy } = game;
+    const dmg = char.stats.atk * 10;
+    enemy.hp = Math.max(0, enemy.hp - dmg);
+    game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 140, 0xffe000, 36);
+  }
+};
+
 export const ABILITIES = {
   'Netrunner': [
     {


### PR DESCRIPTION
## Summary
- remove Basic Attack from player ability generation
- keep popup cards for ability selection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849e8d4b7f88331a85e37aa0d0f7e39