### PR TITLE
Fix ability cards not showing at battle start

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -769,6 +769,7 @@ export class Game {
       startBtn.on('pointerdown', () => {
         this.battleStarted = true;
         buttonContainer.removeChild(startBtn);
+        BattleSystem.generateAbilities(this);
       });
       buttonContainer.addChild(startBtn);
       buttonContainer.x = this.app.screen.width / 2 - startBtn.w / 2;


### PR DESCRIPTION
## Summary
- show ability options once the battle starts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684af459eb848331948c44e2b715252a