### PR TITLE
Add enemy attack effect

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -49,6 +49,8 @@ export class Game {
     this.playerWeaponSprite = null;
     this.attackEffect = null;
     this.attackEffectAnimProgress = 0;
+    this.enemyAttackEffect = null;
+    this.enemyAttackEffectAnimProgress = 0;
     this.shopType = 'weapon';
     // Cache nabídek obchodu (předměty k prodeji podle typu)
     this.shopItemsCache = {
@@ -112,6 +114,7 @@ export class Game {
     assets.push('/assets/avatar background.jpg');
     assets.push('/assets/avatar background.jpg');
     assets.push('/assets/Logo.png');
+    assets.push('/assets/enemy_basic_attack.png');
     // Načtení všech assetů pomocí Pixi Assets API
     await PIXI.Assets.load(assets);
     // Vytvoření sprite pro pozadí hry a aplikace CRT filtru (zkreslení obrazu)
@@ -931,6 +934,12 @@ export class Game {
       this.attackEffect = null;
     }
     this.attackEffectAnimProgress = 0;
+    if (this.enemyAttackEffect) {
+      this.stage.removeChild(this.enemyAttackEffect);
+      this.enemyAttackEffect.destroy();
+      this.enemyAttackEffect = null;
+    }
+    this.enemyAttackEffectAnimProgress = 0;
     this.floatingTexts = [];
     if (this.bloodEffects) {
       this.bloodEffects.forEach(effect => this.stage.removeChild(effect));
@@ -1138,6 +1147,19 @@ export class Game {
           this.attackEffect.destroy();
           this.attackEffect = null;
           this.attackEffectAnimProgress = 0;
+        }
+      }
+      if (this.enemyAttackEffect) {
+        this.enemyAttackEffectAnimProgress += 0.05 * delta;
+        const progress = this.enemyAttackEffectAnimProgress;
+        this.enemyAttackEffect.x = this.enemyShape.x - 30 + (this.charShape.x - this.enemyShape.x + 30) * progress;
+        this.enemyAttackEffect.y = this.enemyShape.y + (this.charShape.y - this.enemyShape.y) * progress;
+        this.enemyAttackEffect.alpha = 1 - progress;
+        if (this.enemyAttackEffectAnimProgress >= 1) {
+          this.battleContainer.removeChild(this.enemyAttackEffect);
+          this.enemyAttackEffect.destroy();
+          this.enemyAttackEffect = null;
+          this.enemyAttackEffectAnimProgress = 0;
         }
       }
       // Animace útoku nepřítele (posun avataru nepřítele při útoku)

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -1,3 +1,4 @@
+import * as PIXI from 'pixi.js';
 import { ABILITIES } from '../data/abilities.js';
 
 export class BattleSystem {
@@ -56,6 +57,18 @@ export class BattleSystem {
 
   static enemyAttack(game) {
     const { character: char, enemy } = game;
+    game.enemyAttacking = true;
+    game.attackAnimProgress = 0;
+    if (game.enemyShape && game.charShape && game.battleContainer) {
+      const effect = PIXI.Sprite.from('/assets/enemy_basic_attack.png');
+      effect.anchor.set(0.5);
+      effect.x = game.enemyShape.x - 30;
+      effect.y = game.enemyShape.y;
+      effect.zIndex = 3;
+      game.battleContainer.addChild(effect);
+      game.enemyAttackEffect = effect;
+      game.enemyAttackEffectAnimProgress = 0;
+    }
     if (BattleSystem.didDodge(char.stats.def)) {
       game.spawnFloatingText('DODGED', game.playerAvatarX, game.playerAvatarY - 140, 0xffffff, 36);
       return;


### PR DESCRIPTION
## Summary
- load new enemy attack asset
- track enemy attack effect state and animate it
- spawn the effect when the enemy attacks

## Testing
- `node -c src/components/Game.js`
- `node -c src/components/battlesystem.js`

------
https://chatgpt.com/codex/tasks/task_e_684af93db7e483319deaf1b94f7e4c57