### PR TITLE
Fix battle avatars by delaying UI reset

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -115,6 +115,10 @@ export class Game {
     assets.push('/assets/avatar background.jpg');
     assets.push('/assets/Logo.png');
     assets.push('/assets/enemy_basic_attack.png');
+    // Class weapon effects
+    assets.push('/assets/samurai_weapon.png');
+    assets.push('/assets/netrunner_weapon.png');
+    assets.push('/assets/techie_gun.png');
     // Načtení všech assetů pomocí Pixi Assets API
     await PIXI.Assets.load(assets);
     // Vytvoření sprite pro pozadí hry a aplikace CRT filtru (zkreslení obrazu)

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -120,11 +120,13 @@ export class BattleSystem {
     if (game.enemy.hp <= 0) {
       game.battleStarted = false;
       game.battleResult = 'win';
-      game.initUI();
+      // wait a moment so victory animations remain visible
+      setTimeout(() => game.initUI(), 500);
     } else if (game.character.hp <= 0) {
       game.battleStarted = false;
       game.battleResult = 'lose';
-      game.initUI();
+      // short delay ensures defeat effects are seen
+      setTimeout(() => game.initUI(), 500);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a timeout in `checkBattleEnd` so avatars stay visible after the fight

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684afd147c2c83318c63f3d6a3ed2699