### PR TITLE
Improve battle asset loading

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -146,6 +146,28 @@ export class Game {
     this.logoSprite.zIndex = 10;
   }
 
+  async ensureAsset(url) {
+    if (!PIXI.Assets.cache.get(url)) {
+      try {
+        await PIXI.Assets.load(url);
+      } catch (err) {
+        console.warn('Failed to load asset:', url, err);
+      }
+    }
+  }
+
+  async startBattle() {
+    const needed = [];
+    if (this.character?.avatar) needed.push(this.character.avatar);
+    if (this.enemy?.avatar) needed.push(this.enemy.avatar);
+    needed.push('/assets/enemy_basic_attack.png');
+    for (const url of needed) {
+      await this.ensureAsset(url);
+    }
+    BattleSystem.init(this);
+    this.createBattleUI();
+  }
+
   spawnFloatingText(text, x, y, color = 0xffffff, fontSize = 24, offsetY = 0) {
     // Vytvoření poletujícího textu (např. poškození nebo zprávy) na scéně
     const floatingText = new PIXI.Text(text, {
@@ -527,17 +549,8 @@ export class Game {
       //this.createShopUI();
     //}
       } else if (this.state === 'battle') {
-  const neededAssets = [];
-
-  if (this.character?.avatar) neededAssets.push(this.character.avatar);
-  if (this.enemy?.avatar) neededAssets.push(this.enemy.avatar);
-  neededAssets.push('/assets/enemy_basic_attack.png');
-
-  PIXI.Assets.load(neededAssets).then(() => {
-    BattleSystem.init(this);
-    this.createBattleUI();
-  });
-}
+        this.startBattle();
+      }
     else if (this.state === 'settings') {
       const title = new PIXI.Text('Settings', { fontFamily: 'monospace', fontSize: 32, fill: 0x00e0ff });
       title.anchor.set(0.5);

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -28,12 +28,12 @@ export class BattleSystem {
     }
   }
 
-  static useAbility(game, ability) {
+  static async useAbility(game, ability) {
     if (!game.battleStarted) return;
     // trigger player attack animation and effect
     game.playerAttacking = true;
     game.attackAnimProgress = 0;
-    BattleSystem.spawnPlayerAttackEffect(game);
+    await BattleSystem.spawnPlayerAttackEffect(game);
 
     ability.execute(game);
     BattleSystem.applyDrone(game);
@@ -65,12 +65,13 @@ export class BattleSystem {
     return atk * 10;
   }
 
-  static spawnPlayerAttackEffect(game) {
+  static async spawnPlayerAttackEffect(game) {
     if (game.charShape && game.battleContainer) {
       let asset = '/assets/samurai_weapon.png';
       const cls = game.character.cls.name;
       if (cls === 'Netrunner') asset = '/assets/netrunner_weapon.png';
       else if (cls === 'Techie') asset = '/assets/techie_gun.png';
+      await game.ensureAsset(asset);
       const effect = PIXI.Sprite.from(asset);
       effect.anchor.set(0.5);
       effect.x = game.charShape.x + 30;
@@ -82,11 +83,12 @@ export class BattleSystem {
     }
   }
 
-  static enemyAttack(game) {
+  static async enemyAttack(game) {
     const { character: char, enemy } = game;
     game.enemyAttacking = true;
     game.attackAnimProgress = 0;
     if (game.enemyShape && game.charShape && game.battleContainer) {
+      await game.ensureAsset('/assets/enemy_basic_attack.png');
       const effect = PIXI.Sprite.from('/assets/enemy_basic_attack.png');
       effect.anchor.set(0.5);
       effect.x = game.enemyShape.x - 30;


### PR DESCRIPTION
## Summary
- add `ensureAsset` helper and `startBattle` async loader
- update game to call `startBattle` for battle scenes
- make attack effect functions async and load assets lazily

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b26efcf108331bc8d51d486c23617