### PR TITLE
Adjust z-index for battle assets

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -638,7 +638,8 @@ console.log("enemy attack asset loaded:", !!PIXI.Assets.cache.get('/assets/enemy
     this.charShape = charAvatar;
     charAvatar.x = this.playerAvatarX;
     charAvatar.y = this.playerAvatarY;
-    charAvatar.zIndex = 2;
+    // Ensure avatar renders above its background
+    charAvatar.zIndex = 5;
     // Filtry pro hráčův avatar (záře, bloom, stín)
     charAvatar.filters = [
       new GlowFilter({ distance: 22, outerStrength: 3, innerStrength: 0, color: char.cls.color, quality: 0.5 }),
@@ -691,7 +692,8 @@ console.log("enemy attack asset loaded:", !!PIXI.Assets.cache.get('/assets/enemy
     this.enemyShape = enemySprite;
     enemySprite.x = this.enemyAvatarX;
     enemySprite.y = this.enemyAvatarY;
-    enemySprite.zIndex = 2;
+    // Ensure enemy avatar appears above its background
+    enemySprite.zIndex = 5;
     // Filtry pro nepřátelský avatar (záře, bloom, stín)
     enemySprite.filters = [
       new GlowFilter({ distance: 25, outerStrength: 4, innerStrength: 0, color: enemy.color, quality: 0.5 }),

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -79,7 +79,8 @@ export class BattleSystem {
       effect.anchor.set(0.5);
       effect.x = game.charShape.x + 30;
       effect.y = game.charShape.y;
-      effect.zIndex = 3;
+      // Display attack effect above avatars
+      effect.zIndex = 6;
       game.battleContainer.addChild(effect);
       game.attackEffect = effect;
       game.attackEffectAnimProgress = 0;
@@ -96,7 +97,8 @@ export class BattleSystem {
       effect.anchor.set(0.5);
       effect.x = game.enemyShape.x - 30;
       effect.y = game.enemyShape.y;
-      effect.zIndex = 3;
+      // Display enemy attack effect above avatars
+      effect.zIndex = 6;
       game.battleContainer.addChild(effect);
       game.enemyAttackEffect = effect;
       game.enemyAttackEffectAnimProgress = 0;


### PR DESCRIPTION
## Summary
- keep avatar sprites above backgrounds
- keep attack effect sprites above avatars

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c5e54a88c8331a3f330f52380c78b