### PR TITLE
Fix battle attack visuals

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -605,14 +605,7 @@ export class Game {
     this.playerAvatarY = this.app.screen.height / 2 - 50;
     this.enemyAvatarX = this.app.screen.width * 3 / 4;
     this.enemyAvatarY = this.app.screen.height / 2 - 50;
-    // log
-console.log("char.avatar =", char.avatar);
-console.log("enemy.avatar =", enemy.avatar);
-console.log("char avatar loaded:", !!PIXI.Assets.cache.get(char.avatar));
-console.log("enemy avatar loaded:", !!PIXI.Assets.cache.get(enemy.avatar));
-console.log("enemy attack asset loaded:", !!PIXI.Assets.cache.get('/assets/enemy_basic_attack.png'));
-    //log
-// Rámečky pod avátory (s efekty)
+    // Rámečky pod avátory (s efekty)
     const playerBgSprite = PIXI.Sprite.from('/assets/avatar background.jpg');
     playerBgSprite.width = AVATAR_BG_SIZE;
     playerBgSprite.height = AVATAR_BG_SIZE;
@@ -1100,18 +1093,22 @@ console.log("enemy attack asset loaded:", !!PIXI.Assets.cache.get('/assets/enemy
       // Flash efekt hráče při zásahu (blikne červeně krátce)
       if (this.playerFlashTimer > 0) {
         this.playerFlashTimer -= delta / 60;
-        this.charShape.tint = 0xff0000;
-        if (this.playerFlashTimer <= 0) {
+        if (this.charShape) this.charShape.tint = 0xff0000;
+        if (this.playerFlashTimer <= 0 && this.charShape) {
           this.charShape.tint = 0xffffff;
         }
+      } else if (this.charShape && this.charShape.tint !== 0xffffff) {
+        this.charShape.tint = 0xffffff;
       }
       // Flash efekt nepřítele při zásahu
       if (this.enemyFlashTimer > 0) {
         this.enemyFlashTimer -= delta / 60;
-        this.enemyShape.tint = 0xff0000;
-        if (this.enemyFlashTimer <= 0) {
+        if (this.enemyShape) this.enemyShape.tint = 0xff0000;
+        if (this.enemyFlashTimer <= 0 && this.enemyShape) {
           this.enemyShape.tint = 0xffffff;
         }
+      } else if (this.enemyShape && this.enemyShape.tint !== 0xffffff) {
+        this.enemyShape.tint = 0xffffff;
       }
       // Animace částic krve (pokud existují)
       if (this.bloodEffects) {

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -79,7 +79,7 @@ export class BattleSystem {
       effect.x = game.charShape.x + 30;
       effect.y = game.charShape.y;
       // Display attack effect above avatars
-      effect.zIndex = 6;
+      effect.zIndex = 8;
       game.battleContainer.addChild(effect);
       game.attackEffect = effect;
       game.attackEffectAnimProgress = 0;
@@ -96,7 +96,7 @@ export class BattleSystem {
       effect.x = game.enemyShape.x - 30;
       effect.y = game.enemyShape.y;
       // Display enemy attack effect above avatars
-      effect.zIndex = 6;
+      effect.zIndex = 8;
       game.battleContainer.addChild(effect);
       game.enemyAttackEffect = effect;
       game.enemyAttackEffectAnimProgress = 0;

--- a/src/data/abilities.js
+++ b/src/data/abilities.js
@@ -6,6 +6,7 @@ export const BASIC_ATTACK = {
     const dmg = char.stats.atk * 10;
     enemy.hp = Math.max(0, enemy.hp - dmg);
     game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 140, 0xffe000, 36);
+    game.enemyFlashTimer = 0.2;
   }
 };
 
@@ -20,6 +21,7 @@ export const ABILITIES = {
         enemy.def = Math.max(1, enemy.def * 0.95);
         enemy.hp = Math.max(0, enemy.hp - dmg);
         game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 140, 0x00e0ff, 36);
+        game.enemyFlashTimer = 0.2;
       }
     }
   ],
@@ -37,6 +39,7 @@ export const ABILITIES = {
         }
         enemy.hp = Math.max(0, enemy.hp - dmg);
         game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 140, crit ? 0xff0000 : 0xff2e2e, 36);
+        game.enemyFlashTimer = 0.2;
       }
     }
   ],
@@ -47,6 +50,7 @@ export const ABILITIES = {
       execute(game) {
         game.droneDamage = Math.round(game.droneDamage * 1.5);
         game.spawnFloatingText('DRONE +50%', game.playerAvatarX, game.playerAvatarY - 160, 0x00ff8a, 32);
+        game.enemyFlashTimer = 0.2;
       }
     }
   ]


### PR DESCRIPTION
## Summary
- adjust UI log comments
- reset flash tint after hit to avoid stuck red avatars
- make player and enemy attack effects render above other sprites
- flash enemy on damage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c734e86508331811124d56be6fc9a