### PR TITLE
Add Techie drone attack animation

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -51,6 +51,8 @@ export class Game {
     this.attackEffectAnimProgress = 0;
     this.enemyAttackEffect = null;
     this.enemyAttackEffectAnimProgress = 0;
+    this.droneAttackEffect = null;
+    this.droneAttackEffectAnimProgress = 0;
     this.shopType = 'weapon';
     // Cache nabídek obchodu (předměty k prodeji podle typu)
     this.shopItemsCache = {
@@ -119,6 +121,7 @@ export class Game {
     assets.push('/assets/samurai_weapon.png');
     assets.push('/assets/netrunner_weapon.png');
     assets.push('/assets/techie_gun.png');
+    assets.push('/assets/techie_drone_attack.png');
     // Načtení všech assetů pomocí Pixi Assets API
     await PIXI.Assets.load(assets);
     // Vytvoření sprite pro pozadí hry a aplikace CRT filtru (zkreslení obrazu)
@@ -972,6 +975,16 @@ export class Game {
       this.enemyAttackEffect = null;
     }
     this.enemyAttackEffectAnimProgress = 0;
+    if (this.droneAttackEffect) {
+      if (this.battleContainer) {
+        this.battleContainer.removeChild(this.droneAttackEffect);
+      } else {
+        this.stage.removeChild(this.droneAttackEffect);
+      }
+      this.droneAttackEffect.destroy();
+      this.droneAttackEffect = null;
+    }
+    this.droneAttackEffectAnimProgress = 0;
     this.floatingTexts = [];
     if (this.bloodEffects) {
       this.bloodEffects.forEach(effect => this.stage.removeChild(effect));
@@ -1186,6 +1199,19 @@ export class Game {
           this.enemyAttackEffect.destroy();
           this.enemyAttackEffect = null;
           this.enemyAttackEffectAnimProgress = 0;
+        }
+      }
+      if (this.droneAttackEffect) {
+        this.droneAttackEffectAnimProgress += 0.05 * delta;
+        const progress = this.droneAttackEffectAnimProgress;
+        this.droneAttackEffect.x = this.charShape.x + 30 + (this.enemyShape.x - this.charShape.x - 30) * progress;
+        this.droneAttackEffect.y = this.charShape.y - 40 + (this.enemyShape.y - this.charShape.y + 40) * progress;
+        this.droneAttackEffect.alpha = 1 - progress;
+        if (this.droneAttackEffectAnimProgress >= 1) {
+          this.battleContainer.removeChild(this.droneAttackEffect);
+          this.droneAttackEffect.destroy();
+          this.droneAttackEffect = null;
+          this.droneAttackEffectAnimProgress = 0;
         }
       }
       // Zobrazení ikonky nepřítele bez animací

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -58,6 +58,7 @@ export class BattleSystem {
       const dmg = game.droneDamage;
       game.enemy.hp = Math.max(0, game.enemy.hp - dmg);
       game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 120, 0x00ff8a, 24);
+      BattleSystem.spawnDroneAttackEffect(game);
     }
   }
 
@@ -83,6 +84,19 @@ export class BattleSystem {
       game.battleContainer.addChild(effect);
       game.attackEffect = effect;
       game.attackEffectAnimProgress = 0;
+    }
+  }
+
+  static spawnDroneAttackEffect(game) {
+    if (game.charShape && game.battleContainer) {
+      const effect = PIXI.Sprite.from('/assets/techie_drone_attack.png');
+      effect.anchor.set(0.5);
+      effect.x = game.charShape.x + 30;
+      effect.y = game.charShape.y - 40;
+      effect.zIndex = 8;
+      game.battleContainer.addChild(effect);
+      game.droneAttackEffect = effect;
+      game.droneAttackEffectAnimProgress = 0;
     }
   }
 


### PR DESCRIPTION
## Summary
- add new effect sprite `techie_drone_attack.png` to preloaded assets
- spawn drone attack animation when Techie drone deals damage
- animate drone projectile in battle scenes
- clean up drone effect when resetting battle state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c7de586a08331aebec9397e1409a1