### PR TITLE
Add brief delay for attack effects

### DIFF
--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -33,7 +33,7 @@ export class BattleSystem {
     // trigger player attack animation and effect
     game.playerAttacking = true;
     game.attackAnimProgress = 0;
-    BattleSystem.spawnPlayerAttackEffect(game);
+    await BattleSystem.spawnPlayerAttackEffect(game);
 
     ability.execute(game);
     BattleSystem.applyDrone(game);
@@ -69,7 +69,7 @@ export class BattleSystem {
     return new Promise(resolve => setTimeout(resolve, ms));
   }
 
-  static spawnPlayerAttackEffect(game) {
+  static async spawnPlayerAttackEffect(game) {
     if (game.charShape && game.battleContainer) {
       let asset = '/assets/samurai_weapon.png';
       const cls = game.character.cls.name;
@@ -84,6 +84,8 @@ export class BattleSystem {
       game.battleContainer.addChild(effect);
       game.attackEffect = effect;
       game.attackEffectAnimProgress = 0;
+      // Allow a brief moment for the texture to load so the effect is visible
+      await BattleSystem.delay(100);
     }
   }
 


### PR DESCRIPTION
## Summary
- show player attack effect after a short delay

## Testing
- `npx eslint src --ext .js,.jsx,.ts,.tsx` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_684c7fb345688331b798bc6209d08303