### PR TITLE
Implement attack zone visuals

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -52,6 +52,10 @@ export class Game {
     this.enemyAttackEffectAnimProgress = 0;
     this.droneAttackEffect = null;
     this.droneAttackEffectAnimProgress = 0;
+    this.attackZone = null;
+    this.attackZoneLife = 0;
+    this.enemyAttackZone = null;
+    this.enemyAttackZoneLife = 0;
     this.shopType = 'weapon';
     // Cache nabídek obchodu (předměty k prodeji podle typu)
     this.shopItemsCache = {
@@ -979,6 +983,26 @@ export class Game {
       this.droneAttackEffect = null;
     }
     this.droneAttackEffectAnimProgress = 0;
+    if (this.attackZone) {
+      if (this.battleContainer) {
+        this.battleContainer.removeChild(this.attackZone);
+      } else {
+        this.stage.removeChild(this.attackZone);
+      }
+      this.attackZone.destroy();
+      this.attackZone = null;
+    }
+    this.attackZoneLife = 0;
+    if (this.enemyAttackZone) {
+      if (this.battleContainer) {
+        this.battleContainer.removeChild(this.enemyAttackZone);
+      } else {
+        this.stage.removeChild(this.enemyAttackZone);
+      }
+      this.enemyAttackZone.destroy();
+      this.enemyAttackZone = null;
+    }
+    this.enemyAttackZoneLife = 0;
     this.floatingTexts = [];
     if (this.bloodEffects) {
       this.bloodEffects.forEach(effect => this.stage.removeChild(effect));
@@ -1206,6 +1230,26 @@ export class Game {
           this.droneAttackEffect.destroy();
           this.droneAttackEffect = null;
           this.droneAttackEffectAnimProgress = 0;
+        }
+      }
+      if (this.attackZone) {
+        this.attackZoneLife += delta / 60;
+        this.attackZone.alpha = 1 - this.attackZoneLife * 2;
+        if (this.attackZoneLife >= 0.5) {
+          this.battleContainer.removeChild(this.attackZone);
+          this.attackZone.destroy();
+          this.attackZone = null;
+          this.attackZoneLife = 0;
+        }
+      }
+      if (this.enemyAttackZone) {
+        this.enemyAttackZoneLife += delta / 60;
+        this.enemyAttackZone.alpha = 1 - this.enemyAttackZoneLife * 2;
+        if (this.enemyAttackZoneLife >= 0.5) {
+          this.battleContainer.removeChild(this.enemyAttackZone);
+          this.enemyAttackZone.destroy();
+          this.enemyAttackZone = null;
+          this.enemyAttackZoneLife = 0;
         }
       }
       // Zobrazení ikonky nepřítele bez animací

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -103,6 +103,18 @@ export class BattleSystem {
       game.battleContainer.addChild(effect);
       game.attackEffect = effect;
       game.attackEffectAnimProgress = 0;
+      if (game.enemyShape) {
+        const zone = new Graphics();
+        zone.beginFill(0xff0000, 0.2);
+        zone.drawCircle(0, 0, 60);
+        zone.endFill();
+        zone.x = game.enemyShape.x;
+        zone.y = game.enemyShape.y;
+        zone.zIndex = 6;
+        game.battleContainer.addChild(zone);
+        game.attackZone = zone;
+        game.attackZoneLife = 0;
+      }
     }
   }
 
@@ -136,6 +148,16 @@ export class BattleSystem {
       game.battleContainer.addChild(effect);
       game.enemyAttackEffect = effect;
       game.enemyAttackEffectAnimProgress = 0;
+      const zone = new Graphics();
+      zone.beginFill(0xff0000, 0.2);
+      zone.drawCircle(0, 0, 60);
+      zone.endFill();
+      zone.x = game.charShape.x;
+      zone.y = game.charShape.y;
+      zone.zIndex = 6;
+      game.battleContainer.addChild(zone);
+      game.enemyAttackZone = zone;
+      game.enemyAttackZoneLife = 0;
     }
     await BattleSystem.delay(400);
     if (BattleSystem.didDodge(char.stats.def)) {


### PR DESCRIPTION
## Summary
- draw translucent zone indicators when player and enemy attack
- animate and clean up zone graphics during battle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d957e13b883318589aa75cffab780