### PR TITLE
Fix import for BLEND_MODES

### DIFF
--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -1,4 +1,5 @@
-import { Graphics, BLEND_MODES } from 'pixi.js';
+import { Graphics } from 'pixi.js';
+import { BLEND_MODES } from '@pixi/constants';
 import { ABILITIES, BASIC_ATTACK } from '../data/abilities.js';
 
 const ENEMY_DELAY = 500;


### PR DESCRIPTION
## Summary
- update battlesystem to import `BLEND_MODES` from `@pixi/constants`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684dd8b7acfc8331a49f1914698d2f46