### PR TITLE
Add descriptions and damage info to combat ability cards

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -819,9 +819,37 @@ export class Game {
     overlay.addChild(bg);
 
     const startX = this.app.screen.width / 2 - 330;
-    const startY = this.app.screen.height / 2 - 60;
+    const startY = this.app.screen.height / 2 - 70;
     abilities.forEach((ab, idx) => {
-      const card = new Button(ab.name, startX + idx * 220, startY, 200, 100, 0x00e0ff);
+      const card = new Button(ab.name, startX + idx * 220, startY, 200, 120, 0x00e0ff);
+      // reposition title
+      card.t.style.fontSize = 20;
+      card.t.anchor.set(0.5, 0);
+      card.t.y = 8;
+
+      const desc = new Text(ab.description, {
+        fontFamily: 'monospace',
+        fontSize: 14,
+        fill: 0xffffff,
+        wordWrap: true,
+        wordWrapWidth: 180,
+        align: 'center'
+      });
+      desc.anchor.set(0.5, 0);
+      desc.x = card.w / 2;
+      desc.y = 36;
+      card.addChild(desc);
+
+      if (ab.damage) {
+        const dmgText = new Text(`DMG: ${ab.damage}`, {
+          fontFamily: 'monospace', fontSize: 14, fill: 0xffe000
+        });
+        dmgText.anchor.set(0.5, 0);
+        dmgText.x = card.w / 2;
+        dmgText.y = card.h - 24;
+        card.addChild(dmgText);
+      }
+
       card.on('pointerdown', () => {
         if (this.battleStarted) {
           this.battleContainer.removeChild(overlay);

--- a/src/data/abilities.js
+++ b/src/data/abilities.js
@@ -1,6 +1,7 @@
 export const BASIC_ATTACK = {
   name: 'Basic Attack',
   description: 'A straightforward strike dealing damage.',
+  damage: 'ATK x10',
   execute(game) {
     const { character: char, enemy } = game;
     const dmg = char.stats.atk * 10;
@@ -15,6 +16,7 @@ export const ABILITIES = {
     {
       name: 'Data Spike',
       description: 'Deals damage and reduces enemy DEF by 5% for the battle.',
+      damage: 'ATK x10',
       execute(game) {
         const { character: char, enemy } = game;
         let dmg = char.stats.atk * 10;
@@ -29,6 +31,7 @@ export const ABILITIES = {
     {
       name: 'Blade Strike',
       description: 'Attack with 30% chance to critically hit.',
+      damage: 'ATK x10 (30% crit)',
       execute(game) {
         const { character: char, enemy } = game;
         let dmg = char.stats.atk * 10;


### PR DESCRIPTION
## Summary
- extend ability data with new optional `damage` field
- rework ability selection UI to display description and damage values on ability cards

## Testing
- `npx --version`

------
https://chatgpt.com/codex/tasks/task_e_684e7566e0ec83319c70ec24a77c440d