### PR TITLE
Show ability damage values

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -840,7 +840,16 @@ export class Game {
       desc.y = 36;
       card.addChild(desc);
 
-      if (ab.damage) {
+      if (typeof ab.getDamage === 'function') {
+        const approx = ab.getDamage(this);
+        const dmgText = new Text(`DMG: ~${approx}`, {
+          fontFamily: 'monospace', fontSize: 14, fill: 0xffe000
+        });
+        dmgText.anchor.set(0.5, 0);
+        dmgText.x = card.w / 2;
+        dmgText.y = card.h - 24;
+        card.addChild(dmgText);
+      } else if (ab.damage) {
         const dmgText = new Text(`DMG: ${ab.damage}`, {
           fontFamily: 'monospace', fontSize: 14, fill: 0xffe000
         });

--- a/src/data/abilities.js
+++ b/src/data/abilities.js
@@ -2,6 +2,9 @@ export const BASIC_ATTACK = {
   name: 'Basic Attack',
   description: 'A straightforward strike dealing damage.',
   damage: 'ATK x10',
+  getDamage(game) {
+    return game.character.stats.atk * 10;
+  },
   execute(game) {
     const { character: char, enemy } = game;
     const dmg = char.stats.atk * 10;
@@ -17,6 +20,9 @@ export const ABILITIES = {
       name: 'Data Spike',
       description: 'Deals damage and reduces enemy DEF by 5% for the battle.',
       damage: 'ATK x10',
+      getDamage(game) {
+        return game.character.stats.atk * 10;
+      },
       execute(game) {
         const { character: char, enemy } = game;
         let dmg = char.stats.atk * 10;
@@ -32,6 +38,9 @@ export const ABILITIES = {
       name: 'Blade Strike',
       description: 'Attack with 30% chance to critically hit.',
       damage: 'ATK x10 (30% crit)',
+      getDamage(game) {
+        return Math.round(game.character.stats.atk * 10 * 1.3);
+      },
       execute(game) {
         const { character: char, enemy } = game;
         let dmg = char.stats.atk * 10;


### PR DESCRIPTION
## Summary
- display approximate damage on ability cards
- add `getDamage` helper for abilities to calculate damage values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e7733bba083318bff7b8f6e5801de