### PR TITLE
Add new Netrunner abilities

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -93,6 +93,8 @@ export class Game {
     this.energyMax = 100;
     this.energyThreshold = 50;
     this.droneDamage = 5;
+    this.glitchPulseTurns = 0;
+    this.glitchPulseDamage = 0;
     this.echoLoopActive = false;
     this.abilityButtons = null;
     this.battleStarted = false;
@@ -1129,6 +1131,8 @@ export class Game {
     this.playerEnergy = 0;
     this.enemyEnergy = 0;
     this.droneDamage = 5;
+    this.glitchPulseTurns = 0;
+    this.glitchPulseDamage = 0;
     this.echoLoopActive = false;
     this.battleStarted = false;
   }

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -49,6 +49,7 @@ export class BattleSystem {
     BattleSystem.turn = 'enemy';
     await BattleSystem.delay(ENEMY_DELAY);
     await BattleSystem.enemyTurn(game);
+    BattleSystem.applyStatusEffects(game);
     if (!game.battleStarted) return;
     BattleSystem.tickCooldowns(game);
     await BattleSystem.delay(UI_DELAY);
@@ -93,6 +94,16 @@ export class BattleSystem {
       game.enemy.hp = Math.max(0, game.enemy.hp - dmg);
       game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 120, 0x00ff8a, 24);
       await BattleSystem.spawnDroneAttackEffect(game);
+    }
+  }
+
+  static applyStatusEffects(game) {
+    if (game.glitchPulseTurns > 0) {
+      const dmg = game.glitchPulseDamage || Math.round(game.character.stats.atk * 5 + game.enemy.maxHp * 0.03);
+      game.enemy.hp = Math.max(0, game.enemy.hp - dmg);
+      game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 120, 0x00e0ff, 24);
+      game.enemyFlashTimer = 0.6;
+      game.glitchPulseTurns -= 1;
     }
   }
 

--- a/src/data/abilities.js
+++ b/src/data/abilities.js
@@ -27,6 +27,43 @@ export const ABILITIES = {
         game.echoLoopActive = true;
         game.spawnFloatingText('Echo Loop', game.playerAvatarX, game.playerAvatarY - 160, 0x00e0ff, 32);
       }
+    },
+    {
+      name: 'Glitch Pulse',
+      cost: 1500,
+      cooldown: 3,
+      description: 'Příští 2 kola po každém tahu nepřítele obdrží dodatečné poškození.',
+      execute(game) {
+        const char = game.character;
+        const enemy = game.enemy;
+        const dmg = Math.round(char.stats.atk * 5 + enemy.maxHp * 0.03);
+        game.glitchPulseDamage = dmg;
+        game.glitchPulseTurns = 2;
+        game.spawnFloatingText('Glitch Pulse', game.enemyAvatarX, game.enemyAvatarY - 160, 0x00e0ff, 32);
+      }
+    },
+    {
+      name: 'Overload Attack',
+      cost: 4500,
+      cooldown: 1,
+      damage: 'ATK x20',
+      description: 'Útok za 200% DMG, 50% šance utržit 10% vlastního HP.',
+      getDamage(game) {
+        return game.character.stats.atk * 20;
+      },
+      execute(game) {
+        const { character: char, enemy } = game;
+        let dmg = char.stats.atk * 20;
+        enemy.hp = Math.max(0, enemy.hp - dmg);
+        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 140, 0x00e0ff, 36);
+        game.enemyFlashTimer = 0.6;
+        if (Math.random() < 0.5) {
+          const recoil = Math.round(char.maxHp * 0.1);
+          char.hp = Math.max(0, char.hp - recoil);
+          game.spawnFloatingText(`-${recoil}`, game.playerAvatarX, game.playerAvatarY - 140, 0xff0000, 36);
+          game.playerFlashTimer = 0.6;
+        }
+      }
     }
   ],
   'Street Samurai': [


### PR DESCRIPTION
## Summary
- add Glitch Pulse and Overload Attack abilities for Netrunner
- track Glitch Pulse status in game state
- handle status effect application in battle system

## Testing
- `node --check src/data/abilities.js`

------
https://chatgpt.com/codex/tasks/task_e_684e89651a048331aab369372f0d052c