### PR TITLE
Add Netrunner Stat Hijack and Trojan Spike spells

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -99,6 +99,8 @@ export class Game {
     this.trojanSpikeMult = 0.5;
     this.statHijackTurns = 0;
     this.statHijackAmount = 0;
+    this.playerStatsText = null;
+    this.enemyStatsText = null;
     this.abilityButtons = null;
     this.battleStarted = false;
     this.battleResult = null;
@@ -668,6 +670,7 @@ export class Game {
     playerStatsText.x = this.playerAvatarX;
     playerStatsText.y = this.playerAvatarY + AVATAR_SIZE / 2 + 60;
     this.battleContainer.addChild(playerStatsText);
+    this.playerStatsText = playerStatsText;
     // Rámeček pro nepřítele
     const enemyBgSprite = Sprite.from('/assets/avatar background.jpg');
     enemyBgSprite.width = AVATAR_BG_SIZE;
@@ -718,6 +721,7 @@ export class Game {
     enemyStatsText.x = this.enemyAvatarX;
     enemyStatsText.y = this.enemyAvatarY + AVATAR_SIZE / 2 + 60;
     this.battleContainer.addChild(enemyStatsText);
+    this.enemyStatsText = enemyStatsText;
     // Přidání již vytvořených floatingTexts (např. při opakovaném vykreslení)
     this.floatingTexts.forEach(text => this.battleContainer.addChild(text));
     // Kontejner pro tlačítka ve spodní části (Continue, apod.)
@@ -1143,6 +1147,24 @@ export class Game {
     this.trojanSpikeMult = 0.5;
     this.statHijackTurns = 0;
     this.statHijackAmount = 0;
+    if (this.playerStatsText) {
+      if (this.battleContainer) {
+        this.battleContainer.removeChild(this.playerStatsText);
+      } else {
+        this.stage.removeChild(this.playerStatsText);
+      }
+      this.playerStatsText.destroy();
+      this.playerStatsText = null;
+    }
+    if (this.enemyStatsText) {
+      if (this.battleContainer) {
+        this.battleContainer.removeChild(this.enemyStatsText);
+      } else {
+        this.stage.removeChild(this.enemyStatsText);
+      }
+      this.enemyStatsText.destroy();
+      this.enemyStatsText = null;
+    }
     this.battleStarted = false;
   }
 
@@ -1232,6 +1254,12 @@ export class Game {
       if (this.enemyHpBar) this.enemyHpBar.updateBar(this.enemy.hp, this.enemy.maxHp);
       if (this.playerEnergyBar) this.playerEnergyBar.updateBar(this.playerEnergy, this.energyMax);
       if (this.enemyEnergyBar) this.enemyEnergyBar.updateBar(this.enemyEnergy, this.energyMax);
+      if (this.playerStatsText) {
+        this.playerStatsText.text = `ATK: ${char.stats.atk} | DEF: ${char.stats.def} | SPD: ${char.stats.spd}`;
+      }
+      if (this.enemyStatsText) {
+        this.enemyStatsText.text = `ATK: ${enemy.atk} | DEF: ${enemy.def} | SPD: ${enemy.spd}`;
+      }
       // Flash efekt hráče při zásahu (blikne červeně krátce)
       if (this.playerFlashTimer > 0) {
         this.playerFlashTimer -= delta / 60;

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -96,6 +96,9 @@ export class Game {
     this.glitchPulseTurns = 0;
     this.glitchPulseDamage = 0;
     this.echoLoopActive = false;
+    this.trojanSpikeMult = 0.5;
+    this.statHijackTurns = 0;
+    this.statHijackAmount = 0;
     this.abilityButtons = null;
     this.battleStarted = false;
     this.battleResult = null;
@@ -932,7 +935,8 @@ export class Game {
     this.stage.addChild(this.shopScrollMask, this.shopItemsContainer);
     // Seznam položek k zobrazení (podle zvolené záložky)
     if (this.shopType === 'ability') {
-      this.shopItemsCache.ability = ABILITIES[this.character.cls.name];
+      this.shopItemsCache.ability = [...ABILITIES[this.character.cls.name]]
+        .sort((a, b) => (a.cost || 0) - (b.cost || 0));
     }
     const itemsToShow = this.shopItemsCache[this.shopType];
     let y = 0;
@@ -1136,6 +1140,9 @@ export class Game {
     this.glitchPulseTurns = 0;
     this.glitchPulseDamage = 0;
     this.echoLoopActive = false;
+    this.trojanSpikeMult = 0.5;
+    this.statHijackTurns = 0;
+    this.statHijackAmount = 0;
     this.battleStarted = false;
   }
 

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -11,6 +11,9 @@ export class BattleSystem {
     BattleSystem.turn = 'player';
     BattleSystem.awaitingChoice = true;
     game.echoLoopActive = false;
+    game.trojanSpikeMult = 0.5;
+    game.statHijackTurns = 0;
+    game.statHijackAmount = 0;
     if (game.character && Array.isArray(game.character.abilities)) {
       game.character.abilities.forEach(ab => { ab.cooldownRemaining = 0; });
     }
@@ -104,6 +107,14 @@ export class BattleSystem {
       game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 120, 0x00e0ff, 24);
       game.enemyFlashTimer = 0.6;
       game.glitchPulseTurns -= 1;
+    }
+    if (game.statHijackTurns > 0) {
+      game.statHijackTurns -= 1;
+      if (game.statHijackTurns === 0 && game.statHijackAmount) {
+        game.character.stats.atk = Math.max(1, game.character.stats.atk - game.statHijackAmount);
+        game.enemy.atk += game.statHijackAmount;
+        game.statHijackAmount = 0;
+      }
     }
   }
 

--- a/src/data/abilities.js
+++ b/src/data/abilities.js
@@ -64,6 +64,43 @@ export const ABILITIES = {
           game.playerFlashTimer = 0.6;
         }
       }
+    },
+    {
+      name: 'Stat Hijack',
+      cost: 350,
+      cooldown: 4,
+      description: 'Ukradne 20% ATK nepřítele na 3 kola.',
+      execute(game) {
+        const char = game.character;
+        const enemy = game.enemy;
+        const amount = Math.round(enemy.atk * 0.2);
+        enemy.atk = Math.max(1, enemy.atk - amount);
+        char.stats.atk += amount;
+        game.statHijackAmount = (game.statHijackAmount || 0) + amount;
+        game.statHijackTurns = 3;
+        game.spawnFloatingText(`+${amount} ATK`, game.playerAvatarX, game.playerAvatarY - 160, 0x00e0ff, 32);
+      }
+    },
+    {
+      name: 'Trojan Spike',
+      cost: 200,
+      cooldown: 1,
+      damage: 'ATK x0.5',
+      description: 'Poškození 50% ATK, každým použitím se násobí 1.5×.',
+      getDamage(game) {
+        const mult = game.trojanSpikeMult || 0.5;
+        return Math.round(game.character.stats.atk * mult);
+      },
+      execute(game) {
+        const char = game.character;
+        const enemy = game.enemy;
+        const mult = game.trojanSpikeMult || 0.5;
+        const dmg = Math.round(char.stats.atk * mult);
+        enemy.hp = Math.max(0, enemy.hp - dmg);
+        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 140, 0x00e0ff, 36);
+        game.enemyFlashTimer = 0.6;
+        game.trojanSpikeMult = mult * 1.5;
+      }
     }
   ],
   'Street Samurai': [


### PR DESCRIPTION
## Summary
- add Stat Hijack and Trojan Spike to the Netrunner abilities list
- sort abilities by price in the shop
- track new temporary effects and multipliers
- reset new status fields properly

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e95376da48331837464658b509311