### PR TITLE
Add glow filter to player avatar

### DIFF
--- a/src/components/Character.js
+++ b/src/components/Character.js
@@ -1,4 +1,5 @@
 import { ABILITIES } from '../data/abilities.js';
+import { GlowFilter } from '@pixi/filter-glow';
 
 export class Character {
   constructor(cls) {
@@ -42,6 +43,15 @@ export class Character {
       weapons: [],
       armors: []
     };
+
+    // Glow effect used when rendering the avatar
+    this.glowFilter = new GlowFilter({
+      distance: 15,
+      outerStrength: 3,
+      innerStrength: 0,
+      color: cls.color,
+      quality: 0.5
+    });
 
     // Learned abilities - start with the class basic ability
     this.abilities = [];

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -361,6 +361,7 @@ export class Game {
       avatar.height = 130;
       avatar.x = this.app.screen.width / 2;
       avatar.y = panelY + 60;
+      avatar.filters = [char.glowFilter];
       this.stage.addChild(avatar);
 
       const classText = new Text(`Class: ${char.cls.name}`, { fontFamily: 'monospace', fontSize: 22, fill: 0xffffff });
@@ -650,13 +651,8 @@ export class Game {
     charAvatar.y = this.playerAvatarY;
     // Ensure avatar renders above its background
     charAvatar.zIndex = 5;
-    // Filtry pro hráčův avatar (záře, bloom, stín)
-    // Filters on some systems caused the avatar to become invisible, so they were removed
-    // charAvatar.filters = [
-    //   new GlowFilter({ distance: 22, outerStrength: 3, innerStrength: 0, color: char.cls.color, quality: 0.5 }),
-    //   new BloomFilter({ threshold: 0.18, bloomScale: 2.2, blur: 13, quality: 0.5 }),
-    //   new DropShadowFilter({ distance: 0, blur: 12, color: 0x000000, alpha: 0.7 })
-    // ];
+    // Apply cyberpunk glow effect on the player's avatar
+    charAvatar.filters = [char.glowFilter];
     this.battleContainer.addChild(charAvatar);
     // Popisek a úroveň hráče
     const charNameText = new Text('ME', { fontFamily: 'monospace', fontSize: 32, fill: 0xffa500, fontWeight: 'bold' });


### PR DESCRIPTION
## Summary
- use `GlowFilter` in `Character` to store avatar filter
- apply the glow to the player's sprite on profile and in battle

## Testing
- No tests run due to user instruction

------
https://chatgpt.com/codex/tasks/task_e_684ef239d71c8331b7c39ca74d00fd35