### PR TITLE
Fix missing filter effects

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,8 @@ import { Game } from './components/Game.js';
     height: 720,
     background: '#181e24', // v8 používá string, ne hex
     antialias: true,
-    resolution: 1
+    resolution: 1,
+    preferWebGPU: false // WebGL has better filter support
   });
 
   // Přidání canvas do DOMu


### PR DESCRIPTION
## Summary
- disable WebGPU renderer so Pixi filters work properly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ef39bf3ec8331b75d511fcd406a4d