### PR TITLE
Display stat conversions in profile view

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -386,10 +386,22 @@ export class Game {
       this.stage.addChild(statHeader);
 
       const statInfo = [
-        { key: 'hp', label: `HP: ${char.hp}/${char.maxHp}` },
-        { key: 'atk', label: `ATK: ${char.stats.atk}` },
-        { key: 'def', label: `DEF: ${char.stats.def}` },
-        { key: 'spd', label: `SPD: ${char.stats.spd}` }
+        {
+          key: 'hp',
+          label: `HP: ${char.hp}/${char.maxHp}`
+        },
+        {
+          key: 'atk',
+          label: `ATK: ${char.stats.atk} \u223c ${BattleSystem.calculateDamage(char.stats.atk, 0)}dmg`
+        },
+        {
+          key: 'def',
+          label: `DEF: ${char.stats.def} \u223c ${(char.stats.def * 0.5).toFixed(1)}% dodge`
+        },
+        {
+          key: 'spd',
+          label: `SPD: ${char.stats.spd} \u223c ${(char.stats.spd * 0.5).toFixed(1)}% crit`
+        }
       ];
       let y = statHeader.y + 10;
       for (const s of statInfo) {


### PR DESCRIPTION
## Summary
- enhance profile view stats with derived info
  - show attack, defence, and speed conversions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f14e44adc833187f45e939ca37138