### PR TITLE
Add DEF damage reduction

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -396,11 +396,11 @@ export class Game {
         },
         {
           key: 'def',
-          label: `DEF: ${char.stats.def} \u223c ${(char.stats.def * 0.5).toFixed(1)}% dodge`
+          label: `DEF: ${char.stats.def} \u223c ${(char.stats.def * 0.5).toFixed(1)}% dodge, ${Math.min(char.stats.def * 0.5, 80).toFixed(1)}% block`
         },
         {
           key: 'spd',
-          label: `SPD: ${char.stats.spd} \u223c ${(char.stats.spd * 0.5).toFixed(1)}% crit`
+          label: `SPD: ${char.stats.spd} \u223c x${(1 + char.stats.spd * 0.01).toFixed(2)} rewards`
         }
       ];
       let y = statHeader.y + 10;

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -119,7 +119,10 @@ export class BattleSystem {
   }
 
   static calculateDamage(atk, def) {
-    return atk * 10;
+    const base = atk * 10;
+    const reduction = Math.min(def * 0.005, 0.8);
+    const dmg = Math.round(base * (1 - reduction));
+    return Math.max(1, dmg);
   }
  static delay(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
## Summary
- tweak `calculateDamage` so DEF blocks incoming damage
- update DEF stat label to show block percentage
- show player's SPD multiplier for rewards instead of crit chance

## Testing
- `No tests run`


------
https://chatgpt.com/codex/tasks/task_e_684f162e59388331881a71e8c448f9a5