### PR TITLE
Adjust DEF damage block formula

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -396,7 +396,7 @@ export class Game {
         },
         {
           key: 'def',
-          label: `DEF: ${char.stats.def} \u223c ${(char.stats.def * 0.5).toFixed(1)}% dodge, ${Math.min(char.stats.def * 0.5, 80).toFixed(1)}% block`
+          label: `DEF: ${char.stats.def} \u223c blocks ${char.stats.def * 5} dmg`
         },
         {
           key: 'spd',

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -120,8 +120,7 @@ export class BattleSystem {
 
   static calculateDamage(atk, def) {
     const base = atk * 10;
-    const reduction = Math.min(def * 0.005, 0.8);
-    const dmg = Math.round(base * (1 - reduction));
+    const dmg = Math.round(base - def * 5);
     return Math.max(1, dmg);
   }
  static delay(ms) {
@@ -219,10 +218,6 @@ export class BattleSystem {
       game.battleContainer.sortChildren();
     }
     await BattleSystem.delay(400);
-    if (BattleSystem.didDodge(char.stats.def)) {
-      game.spawnFloatingText('DODGED', game.playerAvatarX, game.playerAvatarY - 140, 0xffffff, 36);
-      return;
-    }
     let dmg = BattleSystem.calculateDamage(enemy.atk, char.stats.def);
     const crit = Math.random() < enemy.spd * 0.005;
     if (crit) {
@@ -234,10 +229,6 @@ export class BattleSystem {
     game.playerFlashTimer = 0.6; // extend hit flash duration
   }
 
-  static didDodge(def) {
-    const chance = def * 0.005;
-    return Math.random() < chance;
-  }
 
   static checkBattleEnd(game) {
     if (game.enemy.hp <= 0) {


### PR DESCRIPTION
## Summary
- make DEF block a flat 5 damage per point
- show block value in stats menu

## Testing
- No tests included in repo

------
https://chatgpt.com/codex/tasks/task_e_684f19ab1b8c8331b47c649ddbea1497