### PR TITLE
Fix damage text position

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -197,7 +197,7 @@ export class Game {
     floatingText.alpha = 1;
     floatingText.life = 0;
     floatingText.scale.set(1);
-    floatingText.zIndex = 5;
+    floatingText.zIndex = 10;
     this.floatingTexts.push(floatingText);
     if (this.state === 'battle' && this.battleContainer) {
       this.battleContainer.addChild(floatingText);

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -109,10 +109,10 @@ export class BattleSystem {
         if (game.droneCritChance && Math.random() < game.droneCritChance) {
           dmg *= 2;
           crit = true;
-          game.spawnFloatingText('CRIT!', game.enemyAvatarX, game.enemyAvatarY - 140, 0xff0000, 28);
+          game.spawnFloatingText('CRIT!', game.enemyAvatarX, game.enemyAvatarY, 0xff0000, 28);
         }
         game.enemy.hp = Math.max(0, game.enemy.hp - dmg);
-        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 120, crit ? 0xff0000 : 0x00ff8a, 24);
+        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY, crit ? 0xff0000 : 0x00ff8a, 24);
         await BattleSystem.spawnDroneAttackEffect(game);
         if (game.criticalLoopActive && crit && !game.criticalLoopUsed) {
           attacks += 1;
@@ -129,7 +129,7 @@ export class BattleSystem {
     if (game.glitchPulseTurns > 0) {
       const dmg = game.glitchPulseDamage || Math.round(game.character.stats.atk * 5 + game.enemy.maxHp * 0.03);
       game.enemy.hp = Math.max(0, game.enemy.hp - dmg);
-      game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 120, 0x00e0ff, 24);
+      game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY, 0x00e0ff, 24);
       game.enemyFlashTimer = 0.6;
       game.glitchPulseTurns -= 1;
     }
@@ -146,14 +146,14 @@ export class BattleSystem {
       if (game.omegaStrikeDelay === 0) {
         const dmg = Math.round(game.character.stats.atk * 15);
         game.enemy.hp = Math.max(0, game.enemy.hp - dmg);
-        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 120, 0x00ff8a, 24);
+          game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY, 0x00ff8a, 24);
         game.enemyFlashTimer = 0.6;
       }
     }
     if (game.autoMedkitActive) {
       const heal = Math.round(game.character.maxHp * 0.01);
       game.character.hp = Math.min(game.character.maxHp, game.character.hp + heal);
-      game.spawnFloatingText(`+${heal}`, game.playerAvatarX, game.playerAvatarY - 120, 0x00ff8a, 24);
+      game.spawnFloatingText(`+${heal}`, game.playerAvatarX, game.playerAvatarY, 0x00ff8a, 24);
     }
   }
 
@@ -261,14 +261,14 @@ export class BattleSystem {
     const crit = Math.random() < enemy.spd * 0.005;
     if (crit) {
       dmg *= 2;
-      game.spawnFloatingText('CRIT!', game.playerAvatarX, game.playerAvatarY - 160, 0xff0000, 36);
+        game.spawnFloatingText('CRIT!', game.playerAvatarX, game.playerAvatarY, 0xff0000, 36);
     }
     if (game.guardModeTurns > 0) {
       dmg = Math.round(dmg * 0.5);
       game.guardModeTurns -= 1;
     }
     char.hp = Math.max(0, char.hp - dmg);
-    game.spawnFloatingText(`-${dmg}`, game.playerAvatarX, game.playerAvatarY - 140, crit ? 0xff0000 : 0xffe000, 36);
+      game.spawnFloatingText(`-${dmg}`, game.playerAvatarX, game.playerAvatarY, crit ? 0xff0000 : 0xffe000, 36);
     game.playerFlashTimer = 0.6; // extend hit flash duration
   }
 

--- a/src/data/abilities.js
+++ b/src/data/abilities.js
@@ -14,7 +14,7 @@ export const ABILITIES = {
         let dmg = char.stats.atk * 10;
         enemy.def = Math.max(1, enemy.def * 0.95);
         enemy.hp = Math.max(0, enemy.hp - dmg);
-        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 140, 0x00e0ff, 36);
+        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY, 0x00e0ff, 36);
         game.enemyFlashTimer = 0.6; // extend flash duration
       }
     },
@@ -55,12 +55,12 @@ export const ABILITIES = {
         const { character: char, enemy } = game;
         let dmg = char.stats.atk * 20;
         enemy.hp = Math.max(0, enemy.hp - dmg);
-        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 140, 0x00e0ff, 36);
+        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY, 0x00e0ff, 36);
         game.enemyFlashTimer = 0.6;
         if (Math.random() < 0.5) {
           const recoil = Math.round(char.maxHp * 0.1);
           char.hp = Math.max(0, char.hp - recoil);
-          game.spawnFloatingText(`-${recoil}`, game.playerAvatarX, game.playerAvatarY - 140, 0xff0000, 36);
+          game.spawnFloatingText(`-${recoil}`, game.playerAvatarX, game.playerAvatarY, 0xff0000, 36);
           game.playerFlashTimer = 0.6;
         }
       }
@@ -97,7 +97,7 @@ export const ABILITIES = {
         const mult = game.trojanSpikeMult || 0.5;
         const dmg = Math.round(char.stats.atk * mult);
         enemy.hp = Math.max(0, enemy.hp - dmg);
-        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 140, 0x00e0ff, 36);
+        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY, 0x00e0ff, 36);
         game.enemyFlashTimer = 0.6;
         game.trojanSpikeMult = mult * 1.5;
       }
@@ -119,10 +119,10 @@ export const ABILITIES = {
         const crit = Math.random() < 0.3;
         if (crit) {
           dmg *= 2;
-          game.spawnFloatingText('CRIT!', game.enemyAvatarX, game.enemyAvatarY - 160, 0xff0000, 36);
+          game.spawnFloatingText('CRIT!', game.enemyAvatarX, game.enemyAvatarY, 0xff0000, 36);
         }
         enemy.hp = Math.max(0, enemy.hp - dmg);
-        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 140, crit ? 0xff0000 : 0xff2e2e, 36);
+        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY, crit ? 0xff0000 : 0xff2e2e, 36);
         game.enemyFlashTimer = 0.6; // extend flash duration
       }
     }
@@ -198,7 +198,7 @@ export const ABILITIES = {
         let dmg = char.stats.atk * 25;
         enemy.hp = Math.max(0, enemy.hp - dmg);
         game.droneDisabledTurns = 2;
-        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY - 140, 0xff2e2e, 36);
+        game.spawnFloatingText(`-${dmg}`, game.enemyAvatarX, game.enemyAvatarY, 0xff2e2e, 36);
         game.enemyFlashTimer = 0.6;
       }
     },


### PR DESCRIPTION
## Summary
- center floating damage text on avatars
- ensure floating text renders above avatars

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855621b79808331bd8103d4e6e450e1