### PR TITLE
Implement attack animations

### DIFF
--- a/src/components/Attack.js
+++ b/src/components/Attack.js
@@ -1,0 +1,33 @@
+import { Texture, Rectangle, AnimatedSprite } from 'pixi.js';
+
+export class Attack {
+  constructor(sheetUrl, frameWidth = 256, frameHeight = 256, speed = 0.4) {
+    const base = Texture.from(sheetUrl).baseTexture;
+    this.frames = [];
+    const cols = Math.floor(base.width / frameWidth);
+    const rows = Math.floor(base.height / frameHeight);
+    for (let y = 0; y < rows; y++) {
+      for (let x = 0; x < cols; x++) {
+        const rect = new Rectangle(x * frameWidth, y * frameHeight, frameWidth, frameHeight);
+        this.frames.push(new Texture(base, rect));
+      }
+    }
+    this.speed = speed;
+  }
+
+  play(container, x, y) {
+    const sprite = new AnimatedSprite(this.frames);
+    sprite.anchor.set(0.5);
+    sprite.animationSpeed = this.speed;
+    sprite.loop = false;
+    sprite.x = x;
+    sprite.y = y;
+    sprite.onComplete = () => {
+      if (sprite.parent) sprite.parent.removeChild(sprite);
+      sprite.destroy();
+    };
+    container.addChild(sprite);
+    sprite.play();
+    return sprite;
+  }
+}

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -9,6 +9,7 @@ import { StatBar } from './StatBar.js';
 import { Character } from './Character.js';
 import { Enemy } from './Enemy.js';
 import { BattleSystem } from './battlesystem.js';
+import { Attack } from './Attack.js';
 
 import { CLASSES } from '../data/classes.js';
 import { DUNGEON_ENEMIES } from '../data/dungeonEnemies.js';
@@ -49,11 +50,8 @@ export class Game {
     this.shopIdx = 0;
     this.playerWeaponSprite = null;
     this.attackEffect = null;
-    this.attackEffectAnimProgress = 0;
     this.enemyAttackEffect = null;
-    this.enemyAttackEffectAnimProgress = 0;
     this.droneAttackEffect = null;
-    this.droneAttackEffectAnimProgress = 0;
     this.attackZone = null;
     this.attackZoneLife = 0;
     this.enemyAttackZone = null;
@@ -145,9 +143,21 @@ export class Game {
     assets.push('/assets/frame.png');
     assets.push('/assets/ability_frame.png');
     assets.push('/assets/Logo.png');
-    // Attack effect assets were removed; effects are drawn via PIXI Graphics
+    // Attack spritesheets
+    assets.push('/assets/spritesheet/cyber_attack_spritesheet.png');
+    assets.push('/assets/spritesheet/slash_attack_spritesheet.png');
+    assets.push('/assets/spritesheet/drone_attack_spritesheet.png');
+    assets.push('/assets/spritesheet/enemy_attack_spritesheet.png');
     // Načtení všech assetů pomocí Pixi Assets API
     await Assets.load(assets);
+
+    // Initialize attack animations
+    this.attacks = {
+      'Netrunner': new Attack('/assets/spritesheet/cyber_attack_spritesheet.png'),
+      'Street Samurai': new Attack('/assets/spritesheet/slash_attack_spritesheet.png'),
+      'Techie': new Attack('/assets/spritesheet/drone_attack_spritesheet.png'),
+      'Enemy': new Attack('/assets/spritesheet/enemy_attack_spritesheet.png')
+    };
     // Vytvoření sprite pro pozadí hry a aplikace CRT filtru (zkreslení obrazu)
     this.backgroundSprite = Sprite.from('/assets/background.png');
     this.backgroundSprite.width = this.app.screen.width;
@@ -1442,7 +1452,6 @@ export class Game {
       this.attackEffect.destroy();
       this.attackEffect = null;
     }
-    this.attackEffectAnimProgress = 0;
     if (this.enemyAttackEffect) {
       if (this.battleContainer) {
         this.battleContainer.removeChild(this.enemyAttackEffect);
@@ -1452,7 +1461,6 @@ export class Game {
       this.enemyAttackEffect.destroy();
       this.enemyAttackEffect = null;
     }
-    this.enemyAttackEffectAnimProgress = 0;
     if (this.droneAttackEffect) {
       if (this.battleContainer) {
         this.battleContainer.removeChild(this.droneAttackEffect);
@@ -1462,7 +1470,6 @@ export class Game {
       this.droneAttackEffect.destroy();
       this.droneAttackEffect = null;
     }
-    this.droneAttackEffectAnimProgress = 0;
     if (this.attackZone) {
       if (this.battleContainer) {
         this.battleContainer.removeChild(this.attackZone);
@@ -1703,53 +1710,7 @@ export class Game {
         this.playerWeaponSprite.destroy();
         this.playerWeaponSprite = null;
       }
-      // Aktualizace efektu útoku hráče (např. letící střela nebo seknutí)
-      if (this.attackEffect) {
-        this.attackEffectAnimProgress += 0.05 * delta;
-        if (char.cls.name === 'Street Samurai') {
-          const progress = this.attackEffectAnimProgress;
-          this.attackEffect.x = this.charShape.x + 30 + progress * 80;
-          this.attackEffect.y = this.charShape.y - 10 - progress * 20;
-          this.attackEffect.alpha = 1 - progress;
-          this.attackEffect.rotation = -Math.PI / 4 + progress * Math.PI / 2;
-        } else if (char.cls.name === 'Netrunner' || char.cls.name === 'Techie') {
-          const progress = this.attackEffectAnimProgress;
-          this.attackEffect.x = this.charShape.x + 30 + (this.enemyShape.x - this.charShape.x - 30) * progress;
-          this.attackEffect.y = this.charShape.y + (this.enemyShape.y - this.charShape.y) * progress;
-        }
-        if (this.attackEffectAnimProgress >= 1) {
-          this.battleContainer.removeChild(this.attackEffect);
-          this.attackEffect.destroy();
-          this.attackEffect = null;
-          this.attackEffectAnimProgress = 0;
-        }
-      }
-      if (this.enemyAttackEffect) {
-        this.enemyAttackEffectAnimProgress += 0.05 * delta;
-        const progress = this.enemyAttackEffectAnimProgress;
-        this.enemyAttackEffect.x = this.enemyShape.x - 30 + (this.charShape.x - this.enemyShape.x + 30) * progress;
-        this.enemyAttackEffect.y = this.enemyShape.y + (this.charShape.y - this.enemyShape.y) * progress;
-        this.enemyAttackEffect.alpha = 1 - progress;
-        if (this.enemyAttackEffectAnimProgress >= 1) {
-          this.battleContainer.removeChild(this.enemyAttackEffect);
-          this.enemyAttackEffect.destroy();
-          this.enemyAttackEffect = null;
-          this.enemyAttackEffectAnimProgress = 0;
-        }
-      }
-      if (this.droneAttackEffect) {
-        this.droneAttackEffectAnimProgress += 0.05 * delta;
-        const progress = this.droneAttackEffectAnimProgress;
-        this.droneAttackEffect.x = this.charShape.x + 30 + (this.enemyShape.x - this.charShape.x - 30) * progress;
-        this.droneAttackEffect.y = this.charShape.y - 40 + (this.enemyShape.y - this.charShape.y + 40) * progress;
-        this.droneAttackEffect.alpha = 1 - progress;
-        if (this.droneAttackEffectAnimProgress >= 1) {
-          this.battleContainer.removeChild(this.droneAttackEffect);
-          this.droneAttackEffect.destroy();
-          this.droneAttackEffect = null;
-          this.droneAttackEffectAnimProgress = 0;
-        }
-      }
+      // Attack effects handled by AnimatedSprite and removed automatically
       if (this.attackZone) {
         this.attackZoneLife += delta / 60;
         this.attackZone.alpha = 1 - this.attackZoneLife * 2;

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -167,62 +167,34 @@ export class BattleSystem {
   }
 
   static async spawnPlayerAttackEffect(game) {
-    if (game.charShape && game.battleContainer) {
+    if (game.charShape && game.enemyShape && game.battleContainer && game.attacks) {
       const cls = game.character.cls.name;
-      const effect = new Graphics();
-      if (cls === 'Street Samurai') {
-        effect.beginFill(0xffffff);
-        effect.drawRect(-20, -4, 40, 8);
-        effect.endFill();
-      } else if (cls === 'Netrunner') {
-        effect.beginFill(0x00ffff);
-        effect.drawCircle(0, 0, 12);
-        effect.endFill();
-      } else {
-        effect.beginFill(0xffa000);
-        effect.drawCircle(0, 0, 10);
-        effect.endFill();
+      const atk = game.attacks[cls];
+      if (atk) {
+        const sprite = atk.play(game.battleContainer, game.enemyShape.x, game.enemyShape.y);
+        game.attackEffect = sprite;
       }
-      effect.alpha = 0.85;
-      effect.blendMode = BLEND_MODES.ADD;
-      effect.x = game.charShape.x + 30;
-      effect.y = game.charShape.y;
-      effect.zIndex = 8;
-      game.battleContainer.addChild(effect);
-      game.attackEffect = effect;
-      game.attackEffectAnimProgress = 0;
+      const zone = new Graphics();
+      zone.beginFill(0xff0000, 0.2);
+      zone.drawCircle(0, 0, 60);
+      zone.endFill();
+      zone.x = game.enemyShape.x;
+      zone.y = game.enemyShape.y;
+      zone.zIndex = 6;
+      game.battleContainer.addChild(zone);
+      game.attackZone = zone;
+      game.attackZoneLife = 0;
       game.battleContainer.sortChildren();
-      if (game.enemyShape) {
-        const zone = new Graphics();
-        zone.beginFill(0xff0000, 0.2);
-        zone.drawCircle(0, 0, 60);
-        zone.endFill();
-        zone.x = game.enemyShape.x;
-        zone.y = game.enemyShape.y;
-        zone.zIndex = 6;
-        game.battleContainer.addChild(zone);
-        game.attackZone = zone;
-        game.attackZoneLife = 0;
-        game.battleContainer.sortChildren();
-      }
     }
   }
 
   static async spawnDroneAttackEffect(game) {
-    if (game.charShape && game.battleContainer) {
-      const effect = new Graphics();
-      effect.beginFill(0xffe066);
-      effect.drawCircle(0, 0, 10);
-      effect.endFill();
-      effect.alpha = 0.85;
-      effect.blendMode = BLEND_MODES.ADD;
-      effect.x = game.charShape.x + 30;
-      effect.y = game.charShape.y - 40;
-      effect.zIndex = 8;
-      game.battleContainer.addChild(effect);
-      game.droneAttackEffect = effect;
-      game.droneAttackEffectAnimProgress = 0;
-      game.battleContainer.sortChildren();
+    if (game.charShape && game.enemyShape && game.battleContainer && game.attacks) {
+      const atk = game.attacks['Techie'];
+      if (atk) {
+        const sprite = atk.play(game.battleContainer, game.enemyShape.x, game.enemyShape.y);
+        game.droneAttackEffect = sprite;
+      }
     }
   }
 
@@ -230,20 +202,12 @@ export class BattleSystem {
     const { character: char, enemy } = game;
     game.enemyAttacking = true;
     game.attackAnimProgress = 0;
-    if (game.enemyShape && game.charShape && game.battleContainer) {
-      const effect = new Graphics();
-      effect.beginFill(0xff0000);
-      effect.drawCircle(0, 0, 12);
-      effect.endFill();
-      effect.alpha = 0.85;
-      effect.blendMode = BLEND_MODES.ADD;
-      effect.x = game.enemyShape.x - 30;
-      effect.y = game.enemyShape.y;
-      effect.zIndex = 8;
-      game.battleContainer.addChild(effect);
-      game.enemyAttackEffect = effect;
-      game.enemyAttackEffectAnimProgress = 0;
-      game.battleContainer.sortChildren();
+    if (game.enemyShape && game.charShape && game.battleContainer && game.attacks) {
+      const atk = game.attacks['Enemy'];
+      if (atk) {
+        const sprite = atk.play(game.battleContainer, game.charShape.x, game.charShape.y);
+        game.enemyAttackEffect = sprite;
+      }
       const zone = new Graphics();
       zone.beginFill(0xff0000, 0.2);
       zone.drawCircle(0, 0, 60);


### PR DESCRIPTION
## Summary
- add Attack class for playing spritesheet-based animations
- load and initialize attack spritesheets in game setup
- swap existing attack effects to animated sprites
- clean up obsolete animation code

## Testing
- `apt-get update`
- `apt-get install -y python3-pil`

------
https://chatgpt.com/codex/tasks/task_e_68557588ec548331a9197a54b0de39f4