### PR TITLE
Fix attack animation visuals

### DIFF
--- a/src/components/Attack.js
+++ b/src/components/Attack.js
@@ -1,4 +1,4 @@
-import { Graphics, Sprite } from 'pixi.js';
+import { Graphics, Sprite, Assets, Texture } from 'pixi.js';
 
 export class Attack {
   constructor(options = {}) {
@@ -14,7 +14,8 @@ export class Attack {
   play(container, startX, startY, endX, endY, ticker) {
     let obj;
     if (this.texture) {
-      obj = Sprite.from(this.texture);
+      const tex = Assets.get(this.texture) || Texture.from(this.texture);
+      obj = new Sprite(tex);
       obj.anchor.set(0.5);
     } else {
       obj = new Graphics();

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -181,17 +181,7 @@ export class BattleSystem {
         );
         game.attackEffect = sprite;
       }
-      const zone = new Graphics();
-      zone.beginFill(0xff0000, 0.2);
-      zone.drawCircle(0, 0, 60);
-      zone.endFill();
-      zone.x = game.enemyShape.x;
-      zone.y = game.enemyShape.y;
-      zone.zIndex = 6;
-      game.battleContainer.addChild(zone);
-      game.attackZone = zone;
-      game.attackZoneLife = 0;
-      game.battleContainer.sortChildren();
+      // projectile animation handled by Attack class
     }
   }
 
@@ -229,17 +219,7 @@ export class BattleSystem {
         );
         game.enemyAttackEffect = sprite;
       }
-      const zone = new Graphics();
-      zone.beginFill(0xff0000, 0.2);
-      zone.drawCircle(0, 0, 60);
-      zone.endFill();
-      zone.x = game.charShape.x;
-      zone.y = game.charShape.y;
-      zone.zIndex = 6;
-      game.battleContainer.addChild(zone);
-      game.enemyAttackZone = zone;
-      game.enemyAttackZoneLife = 0;
-      game.battleContainer.sortChildren();
+      // projectile animation handled by Attack class
     }
     await BattleSystem.delay(400);
     let dmg = BattleSystem.calculateDamage(enemy.atk, char.stats.def);


### PR DESCRIPTION
## Summary
- remove red attack zone circles from battle system
- ensure projectile textures are used for attack animations

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68559fa7a16083319572f07c3d55aeab