### PR TITLE
Fix battle freeze after status effect kill

### DIFF
--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -53,6 +53,7 @@ export class BattleSystem {
     await BattleSystem.delay(ENEMY_DELAY);
     await BattleSystem.enemyTurn(game);
     BattleSystem.applyStatusEffects(game);
+    BattleSystem.checkBattleEnd(game);
     if (!game.battleStarted) return;
     BattleSystem.tickCooldowns(game);
     await BattleSystem.delay(UI_DELAY);


### PR DESCRIPTION
## Summary
- check for battle end after applying status effects so battles end properly when a status effect drops enemy HP to zero

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855a96e5af48331814ea96dd95341ef