### PR TITLE
Fix enemy kill freeze caused by lingering attack animations

### DIFF
--- a/src/components/Attack.js
+++ b/src/components/Attack.js
@@ -58,6 +58,7 @@ export class Attack {
         obj.destroy();
       }, (dist / this.speed) * 16 + 100);
     }
+    obj._update = update;
     return obj;
   }
 }

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -1444,6 +1444,9 @@ export class Game {
     this.attackAnimProgress = 0;
     this.playerWeaponSprite = null;
     if (this.attackEffect) {
+      if (this.attackEffect._update) {
+        this.app.ticker.remove(this.attackEffect._update);
+      }
       if (this.battleContainer) {
         this.battleContainer.removeChild(this.attackEffect);
       } else {
@@ -1453,6 +1456,9 @@ export class Game {
       this.attackEffect = null;
     }
     if (this.enemyAttackEffect) {
+      if (this.enemyAttackEffect._update) {
+        this.app.ticker.remove(this.enemyAttackEffect._update);
+      }
       if (this.battleContainer) {
         this.battleContainer.removeChild(this.enemyAttackEffect);
       } else {
@@ -1462,6 +1468,9 @@ export class Game {
       this.enemyAttackEffect = null;
     }
     if (this.droneAttackEffect) {
+      if (this.droneAttackEffect._update) {
+        this.app.ticker.remove(this.droneAttackEffect._update);
+      }
       if (this.battleContainer) {
         this.battleContainer.removeChild(this.droneAttackEffect);
       } else {


### PR DESCRIPTION
## Summary
- prevent lingering attack animations from freezing battle state
- attach update handler to attack sprite so it can be removed
- clear update handlers when resetting battle state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855ac7bed60833189b52d7fbeb6d81b