### PR TITLE
Implement energy regeneration system

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -84,9 +84,9 @@ export class Game {
     this.screenShakeIntensity = 0;
     this.playerFlashTimer = 0;
     this.enemyFlashTimer = 0;
-    this.playerEnergy = 0;
-    this.enemyEnergy = 0;
     this.energyMax = 100;
+    this.playerEnergy = this.energyMax;
+    this.enemyEnergy = this.energyMax;
     this.energyThreshold = 50;
     this.droneDamage = 5;
     this.overclockTurns = 0;

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -10,6 +10,8 @@ export class BattleSystem {
   static init(game) {
     BattleSystem.turn = 'player';
     BattleSystem.awaitingChoice = true;
+    game.playerEnergy = game.energyMax;
+    game.enemyEnergy = game.energyMax;
     game.echoLoopActive = false;
     game.trojanSpikeMult = 0.5;
     game.statHijackTurns = 0;
@@ -22,6 +24,12 @@ export class BattleSystem {
 
   static update(game, delta) {
     // turn-based system does not act automatically
+  }
+
+  static regenerateEnergy(game) {
+    const regen = Math.round(game.energyMax * 0.25);
+    game.playerEnergy = Math.min(game.energyMax, game.playerEnergy + regen);
+    game.enemyEnergy = Math.min(game.energyMax, game.enemyEnergy + regen);
   }
 
   static generateAbilities(game) {
@@ -56,6 +64,7 @@ export class BattleSystem {
     BattleSystem.checkBattleEnd(game);
     if (!game.battleStarted) return;
     BattleSystem.tickCooldowns(game);
+    BattleSystem.regenerateEnergy(game);
     await BattleSystem.delay(UI_DELAY);
 
     BattleSystem.turn = 'player';


### PR DESCRIPTION
## Summary
- initialize player and enemy energy to max when battle starts
- add energy regeneration each round

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856b045ead88331954ebcd81086f092