### PR TITLE
Modify Street Samurai abilities

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -106,8 +106,14 @@ export class Game {
     this.statHijackAmount = 0;
     this.unrelentingAssaultActive = false;
     this.perfectFocusReady = false;
+    this.perfectFocusCritBonus = 0;
     this.ghostStepActive = false;
     this.heartpiercerTurns = 0;
+    this.heartpiercerDefTurns = 0;
+    this.heartpiercerDefLoss = 0;
+    this.lastStandTurns = 0;
+    this.lastStandDefLoss = 0;
+    this.enemyStunTurns = 0;
     this.playerStunTurns = 0;
     this.playerStatsText = null;
     this.enemyStatsText = null;
@@ -1565,8 +1571,14 @@ export class Game {
     this.statHijackAmount = 0;
     this.unrelentingAssaultActive = false;
     this.perfectFocusReady = false;
+    this.perfectFocusCritBonus = 0;
     this.ghostStepActive = false;
     this.heartpiercerTurns = 0;
+    this.heartpiercerDefTurns = 0;
+    this.heartpiercerDefLoss = 0;
+    this.lastStandTurns = 0;
+    this.lastStandDefLoss = 0;
+    this.enemyStunTurns = 0;
     this.playerStunTurns = 0;
     if (this.character) {
       this.character.updateStats();

--- a/src/components/battlesystem.js
+++ b/src/components/battlesystem.js
@@ -109,6 +109,12 @@ export class BattleSystem {
   }
 
   static async enemyTurn(game) {
+    if (game.enemyStunTurns > 0) {
+      game.spawnFloatingText('Stunned!', game.enemyAvatarX, game.enemyAvatarY - 160, 0xff0000, 32);
+      game.enemyStunTurns -= 1;
+      await BattleSystem.delay(ENEMY_DELAY);
+      return;
+    }
     await BattleSystem.enemyAttack(game);
     await BattleSystem.applyDrone(game);
     BattleSystem.checkBattleEnd(game);
@@ -189,6 +195,20 @@ export class BattleSystem {
       const inc = Math.round(game.character.baseStats.atk * 0.05);
       game.character.stats.atk += inc;
       game.spawnFloatingText(`+${inc} ATK`, game.playerAvatarX, game.playerAvatarY - 160, 0xffe000, 24);
+    }
+    if (game.lastStandTurns > 0) {
+      game.lastStandTurns -= 1;
+      if (game.lastStandTurns === 0 && game.lastStandDefLoss) {
+        game.character.stats.def = Math.max(1, game.character.stats.def + game.lastStandDefLoss);
+        game.lastStandDefLoss = 0;
+      }
+    }
+    if (game.heartpiercerDefTurns > 0) {
+      game.heartpiercerDefTurns -= 1;
+      if (game.heartpiercerDefTurns === 0 && game.heartpiercerDefLoss) {
+        game.enemy.def = Math.max(1, game.enemy.def + game.heartpiercerDefLoss);
+        game.heartpiercerDefLoss = 0;
+      }
     }
     if (game.heartpiercerTurns > 0) {
       game.heartpiercerTurns -= 1;


### PR DESCRIPTION
## Summary
- adjust Street Samurai ability costs and cooldowns
- implement new effects for Last Stand, Execution, Bloodbath, Ghost Step and Heartpiercer
- add critical bonus handling for Perfect Focus
- track temporary DEF reductions and enemy stun

## Testing
- `pre-commit` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_6856c8d4bbf08331970cde1e60b08a8b